### PR TITLE
Switch signout to use logout hint param

### DIFF
--- a/src/auth/get-sign-out-url.js
+++ b/src/auth/get-sign-out-url.js
@@ -2,7 +2,7 @@ import { getOidcConfig } from './get-oidc-config.js'
 import { createState } from './state.js'
 import { config } from '../config/index.js'
 
-async function getSignOutUrl (request, token) {
+async function getSignOutUrl (request, loginHint) {
   const { end_session_endpoint: url } = await getOidcConfig()
 
   // To prevent CSRF attacks, the state parameter should be passed during redirection
@@ -12,7 +12,7 @@ async function getSignOutUrl (request, token) {
 
   const query = [
     `post_logout_redirect_uri=${config.get('entra.signOutRedirectUrl')}`,
-    `id_token_hint=${token}`,
+    `logout_hint=${loginHint}`,
     `state=${state}`
   ].join('&')
   return encodeURI(`${url}?${query}`)

--- a/src/plugins/auth.js
+++ b/src/plugins/auth.js
@@ -10,6 +10,8 @@ export const auth = {
     register: async (server) => {
       const oidcConfig = await getOidcConfig()
 
+      console.log('OIDC Config:', oidcConfig)
+
       // Bell is a third-party plugin that provides a common interface for OAuth 2.0 authentication
       // Used to authenticate users with Entra and a pre-requisite for the Cookie authentication strategy
       // Also used for changing organisations and signing out
@@ -83,7 +85,8 @@ function getProfile (credentials, _params, _get) {
   // Add some additional properties to the profile object for convenience
   credentials.profile = {
     ...payload,
-    sessionId: payload.sid
+    sessionId: payload.sid,
+    loginHint: payload.login_hint
   }
 }
 

--- a/src/routes/auth-routes.js
+++ b/src/routes/auth-routes.js
@@ -65,7 +65,7 @@ const signOut = {
     if (!request.auth.isAuthenticated) {
       return h.redirect('/')
     }
-    const signOutUrl = await getSignOutUrl(request, request.auth.credentials.token)
+    const signOutUrl = await getSignOutUrl(request, request.auth.credentials.loginHint)
     return h.redirect(signOutUrl)
   }
 }

--- a/test/unit/auth/get-sign-out-url.test.js
+++ b/test/unit/auth/get-sign-out-url.test.js
@@ -22,7 +22,7 @@ vi.mock('../../../src/config/index.js', () => ({
 const { getSignOutUrl } = await import('../../../src/auth/get-sign-out-url.js')
 
 const request = { mock: 'request' }
-const token = 'ENTRA-ID-JWT'
+const loginHint = 'Entra-Login-Hint'
 
 describe('getSignOutUrl', () => {
   beforeEach(() => {
@@ -33,60 +33,60 @@ describe('getSignOutUrl', () => {
   })
 
   test('should get oidc config', async () => {
-    await getSignOutUrl(request, token)
+    await getSignOutUrl(request, loginHint)
     expect(mockGetOidcConfig).toHaveBeenCalled()
   })
 
   test('should create state from request', async () => {
-    await getSignOutUrl(request, token)
+    await getSignOutUrl(request, loginHint)
     expect(mockCreateState).toHaveBeenCalledWith(request)
   })
 
   test('should get redirect url from config', async () => {
-    await getSignOutUrl(request, token)
+    await getSignOutUrl(request, loginHint)
     expect(mockConfigGet).toHaveBeenCalledWith('entra.signOutRedirectUrl')
   })
 
   test('should return url with post_logout_redirect_uri as sign out url from config', async () => {
-    const result = await getSignOutUrl(request, token)
+    const result = await getSignOutUrl(request, loginHint)
     expect(result).toContain(`post_logout_redirect_uri=${mockSignOutRedirectUrl}`)
   })
 
-  test('should return url with id_token_hint token', async () => {
-    const result = await getSignOutUrl(request, token)
-    expect(result).toContain(`id_token_hint=${token}`)
+  test('should return url with logout_hint as login hint', async () => {
+    const result = await getSignOutUrl(request, loginHint)
+    expect(result).toContain(`logout_hint=${loginHint}`)
   })
 
   test('should return url with created state', async () => {
-    const result = await getSignOutUrl(request, token)
+    const result = await getSignOutUrl(request, loginHint)
     expect(result).toContain('state=mock-state')
   })
 
   test('should return url with all parameters encoded', async () => {
     mockCreateState.mockReturnValue('mock state')
-    const result = await getSignOutUrl(request, token)
+    const result = await getSignOutUrl(request, loginHint)
     expect(result).toContain('state=mock%20state')
   })
 
   test('should return all properties in correctly formatted url', async () => {
-    const result = await getSignOutUrl(request, token)
+    const result = await getSignOutUrl(request, loginHint)
     const url = new URL(result)
     const params = new URLSearchParams(url.searchParams)
     expect(url.protocol).toBe('https:')
     expect(url.host).toBe('example.com')
     expect(url.pathname).toBe('/sign-out')
     expect(params.get('post_logout_redirect_uri')).toBe(mockSignOutRedirectUrl)
-    expect(params.get('id_token_hint')).toBe(token)
+    expect(params.get('logout_hint')).toBe(loginHint)
     expect(params.get('state')).toBe('mock-state')
   })
 
   test('should throw an error if oidc config request fails', async () => {
     mockGetOidcConfig.mockRejectedValue(new Error('Test error'))
-    await expect(getSignOutUrl(request, token)).rejects.toThrow('Test error')
+    await expect(getSignOutUrl(request, loginHint)).rejects.toThrow('Test error')
   })
 
   test('should throw an error if state creation fails', async () => {
     mockCreateState.mockImplementation(() => { throw new Error('Test error') })
-    await expect(getSignOutUrl(request, token)).rejects.toThrow('Test error')
+    await expect(getSignOutUrl(request, loginHint)).rejects.toThrow('Test error')
   })
 })


### PR DESCRIPTION
When signing out, original setup `id_token_hint` was passed as a query parameter when redirecting to the Entra sign out endpoint.  The value of this parameter is the Entra JWT token.

This works successfully, however if a user has a significant number of internal user roles within Defra, the query string containing the token value can grow to a significant size.

This causes an issue as CDP WAF and even Entra itself reject query strings that are too long.  Both myself and @rtasalem were unable to sign out of this service because of this issue.

This change replaces `id_token_hint` with `logout_hint`.  

The value of `logout_hint` should be (confusingly) set to be the value of the `login_hint` provided in the token.  This value is consistently a much smaller value.  It is also the approach taken by the CDP Portal and some other Defra services.

Once blocker to this is that the SFD App Registrations do not expose the `login_hint`.  Change request `CHG0121575` has been scheduled for 5 February 2026 to enable this in all environments.

This has therefore been successfully tested against a personal Entra tenant mirroring the setup.

This PR can be merged without the dependency being met as the user will just be redirected to a sign out of all page with an undefined `login_hint`.  However, to avoid two rounds of testing, it may be worth waiting before merging.