### PR TITLE
Remove jwk-to-pem dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-sfd-frontend-internal",
-  "version": "0.60.0",
+  "version": "0.100.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-sfd-frontend-internal",
-      "version": "0.60.0",
+      "version": "0.100.0",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
@@ -39,7 +39,6 @@
         "http-status-codes": "2.3.0",
         "https-proxy-agent": "7.0.6",
         "ioredis": "5.4.1",
-        "jwk-to-pem": "2.0.7",
         "nunjucks": "3.2.4",
         "pino": "9.5.0",
         "pino-pretty": "13.0.0",
@@ -3621,18 +3620,6 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
-    "node_modules/asn1.js": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3797,12 +3784,6 @@
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/bn.js": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-      "license": "MIT"
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -3839,12 +3820,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-      "license": "MIT"
     },
     "node_modules/browserslist": {
       "version": "4.24.5",
@@ -4958,21 +4933,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.150.tgz",
       "integrity": "sha512-rOOkP2ZUMx1yL4fCxXQKDHQ8ZXwisb2OycOQVKHgvB3ZI4CvehOd4y2tfnnLDieJ3Zs1RL1Dlp3cMkyIn7nnXA==",
       "license": "ISC"
-    },
-    "node_modules/elliptic": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -7011,16 +6971,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -7039,17 +6989,6 @@
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
       "license": "MIT"
-    },
-    "node_modules/hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-      "license": "MIT",
-      "dependencies": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
     },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
@@ -7274,6 +7213,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -8136,17 +8076,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/jwk-to-pem": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/jwk-to-pem/-/jwk-to-pem-2.0.7.tgz",
-      "integrity": "sha512-cSVphrmWr6reVchuKQZdfSs4U9c5Y4hwZggPoz6cbVnTpAVgGRpEuQng86IyqLeGZlhTh+c4MAreB6KbdQDKHQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "asn1.js": "^5.3.0",
-        "elliptic": "^6.6.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8545,18 +8474,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "license": "ISC"
-    },
-    "node_modules/minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "http-status-codes": "2.3.0",
     "https-proxy-agent": "7.0.6",
     "ioredis": "5.4.1",
-    "jwk-to-pem": "2.0.7",
     "nunjucks": "3.2.4",
     "pino": "9.5.0",
     "pino-pretty": "13.0.0",

--- a/src/auth/verify-token.js
+++ b/src/auth/verify-token.js
@@ -1,6 +1,6 @@
+import { createPublicKey } from 'node:crypto'
 import Wreck from '@hapi/wreck'
 import Jwt from '@hapi/jwt'
-import jwkToPem from 'jwk-to-pem'
 import { getOidcConfig } from './get-oidc-config.js'
 
 async function verifyToken (token) {
@@ -21,7 +21,7 @@ async function verifyToken (token) {
     throw new Error(`No matching JWK for kid ${header.kid}`)
   }
 
-  const pem = jwkToPem(jwk)
+  const pem = createPublicKey({ key: jwk, format: 'jwk' }).export({ type: 'spki', format: 'pem' })
 
   Jwt.token.verify(decoded, { key: pem, algorithm: 'RS256' })
 

--- a/test/unit/auth/verify-token.test.js
+++ b/test/unit/auth/verify-token.test.js
@@ -1,0 +1,115 @@
+import { vi, beforeEach, describe, test, expect } from 'vitest'
+
+const mockKid = 'test-kid'
+const mockToken = 'mock.jwt.token'
+const mockJwksUri = 'https://example.com/jwks'
+const mockPem = '-----BEGIN PUBLIC KEY-----\nMOCK\n-----END PUBLIC KEY-----'
+
+const mockDecode = vi.fn()
+const mockVerify = vi.fn()
+vi.mock('@hapi/jwt', () => ({
+  default: {
+    token: {
+      decode: mockDecode,
+      verify: mockVerify
+    }
+  }
+}))
+
+const mockWreckGet = vi.fn()
+vi.mock('@hapi/wreck', () => ({
+  default: {
+    get: mockWreckGet
+  }
+}))
+
+const mockGetOidcConfig = vi.fn()
+vi.mock('../../../src/auth/get-oidc-config.js', () => ({
+  getOidcConfig: mockGetOidcConfig
+}))
+
+const mockExport = vi.fn()
+const mockCreatePublicKey = vi.fn()
+vi.mock('node:crypto', () => ({
+  createPublicKey: mockCreatePublicKey
+}))
+
+const { verifyToken } = await import('../../../src/auth/verify-token.js')
+
+const mockJwk = { kid: mockKid, kty: 'RSA', n: 'mock-n', e: 'AQAB' }
+const mockDecoded = { decoded: { header: { kid: mockKid } } }
+
+describe('verifyToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDecode.mockReturnValue(mockDecoded)
+    mockGetOidcConfig.mockResolvedValue({ jwks_uri: mockJwksUri })
+    mockWreckGet.mockResolvedValue({ payload: { keys: [mockJwk] } })
+    mockExport.mockReturnValue(mockPem)
+    mockCreatePublicKey.mockReturnValue({ export: mockExport })
+  })
+
+  test('should decode the token', async () => {
+    await verifyToken(mockToken)
+    expect(mockDecode).toHaveBeenCalledWith(mockToken)
+  })
+
+  test('should get oidc config to retrieve jwks_uri', async () => {
+    await verifyToken(mockToken)
+    expect(mockGetOidcConfig).toHaveBeenCalled()
+  })
+
+  test('should fetch jwks from the jwks_uri', async () => {
+    await verifyToken(mockToken)
+    expect(mockWreckGet).toHaveBeenCalledWith(mockJwksUri, { json: true })
+  })
+
+  test('should find the matching jwk by kid', async () => {
+    const otherJwk = { kid: 'other-kid', kty: 'RSA' }
+    mockWreckGet.mockResolvedValue({ payload: { keys: [otherJwk, mockJwk] } })
+    await verifyToken(mockToken)
+    expect(mockCreatePublicKey).toHaveBeenCalledWith({ key: mockJwk, format: 'jwk' })
+  })
+
+  test('should match jwk by x5t when kid does not match', async () => {
+    const x5tJwk = { x5t: mockKid, kty: 'RSA' }
+    mockWreckGet.mockResolvedValue({ payload: { keys: [x5tJwk] } })
+    await verifyToken(mockToken)
+    expect(mockCreatePublicKey).toHaveBeenCalledWith({ key: x5tJwk, format: 'jwk' })
+  })
+
+  test('should throw an error when no matching jwk is found', async () => {
+    mockWreckGet.mockResolvedValue({ payload: { keys: [{ kid: 'different-kid' }] } })
+    await expect(verifyToken(mockToken)).rejects.toThrow(`No matching JWK for kid ${mockKid}`)
+  })
+
+  test('should create public key from matching jwk in jwk format', async () => {
+    await verifyToken(mockToken)
+    expect(mockCreatePublicKey).toHaveBeenCalledWith({ key: mockJwk, format: 'jwk' })
+  })
+
+  test('should export the public key as spki pem', async () => {
+    await verifyToken(mockToken)
+    expect(mockExport).toHaveBeenCalledWith({ type: 'spki', format: 'pem' })
+  })
+
+  test('should verify the token with the pem key and RS256 algorithm', async () => {
+    await verifyToken(mockToken)
+    expect(mockVerify).toHaveBeenCalledWith(mockDecoded, { key: mockPem, algorithm: 'RS256' })
+  })
+
+  test('should throw if getOidcConfig fails', async () => {
+    mockGetOidcConfig.mockRejectedValue(new Error('OIDC config unavailable'))
+    await expect(verifyToken(mockToken)).rejects.toThrow('OIDC config unavailable')
+  })
+
+  test('should throw if jwks request fails', async () => {
+    mockWreckGet.mockRejectedValue(new Error('JWKS fetch failed'))
+    await expect(verifyToken(mockToken)).rejects.toThrow('JWKS fetch failed')
+  })
+
+  test('should throw if token verification fails', async () => {
+    mockVerify.mockImplementation(() => { throw new Error('Invalid token') })
+    await expect(verifyToken(mockToken)).rejects.toThrow('Invalid token')
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SFD2-1048
https://defra-digital-team.slack.com/archives/C09P7PXLEA0/p1775816974296079

This PR removes the jwk-to-pem dependency and replaces it with native functionality from Node’s crypto module.

Many frontend services use jwk-to-pem to support verification of signed tokens after sign-in (both internal and external frontends).

A low-severity vulnerability has recently been identified in elliptic, a dependency of jwk-to-pem. This may have appeared in GitHub Security alerts or during npm audit.

The elliptic package does not appear to be actively maintained, and there has been no resolution to the reported vulnerability.

**Change**
Recent versions of Node.js provide the required functionality via the built-in node:crypto module, meaning jwk-to-pem is no longer required.

**This PR:**
Removes the jwk-to-pem dependency
Updates token verification logic to use node:crypto
