### PR TITLE
Align docker compose file with sfd services

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -1,3 +1,4 @@
+name: fcp-sfd
 services:
   fcp-sfd-frontend-internal:
     ports:
@@ -11,7 +12,7 @@ services:
 
   kits-mock:
     ports:
-      - '3100:3100'
+      - '3101:3100'
     networks:
       - fcp-sfd
 
@@ -23,7 +24,7 @@ services:
 
   redis:
     ports:
-      - '6379:6379'
+      - '6380:6379'
     networks:
       - fcp-sfd
 


### PR DESCRIPTION
As part of the tech debt cleanup, we are aligning the docker compose files within the sfd services. This is to enable us to spin up all the containers with a single command and have non of the services clashing on ports.
