### PR TITLE
SFD2-973: Upgrade @hapi/scooter to v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@hapi/hapi": "21.3.12",
         "@hapi/inert": "7.1.0",
         "@hapi/jwt": "3.2.0",
-        "@hapi/scooter": "7.0.0",
+        "@hapi/scooter": "8.0.0",
         "@hapi/vision": "7.0.3",
         "@hapi/wreck": "18.1.0",
         "@hapi/yar": "11.0.2",
@@ -1418,13 +1418,12 @@
       }
     },
     "node_modules/@hapi/scooter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/scooter/-/scooter-7.0.0.tgz",
-      "integrity": "sha512-4IRfzq638VM69hzjfQPIINjeBmgE+J5v3v+4DEKZR1lvCykCTXhggbXmZYGVJHpFAkIJ68VMeKX6NtXDFINALg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/scooter/-/scooter-8.0.0.tgz",
+      "integrity": "sha512-/AeDM9t2L+yXTQ5z6aWhlfVR7VOBqHc5KC58+9FjWpU5ijXmJGurYTKR7BbYTZdN9LYTHlX4s00Dd8Ykme0TjQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "semver": "^7.3.8",
-        "useragent": "^2.3.0"
+        "my-ua-parser": "^2.0.4"
       }
     },
     "node_modules/@hapi/shot": {
@@ -8513,6 +8512,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/my-ua-parser": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/my-ua-parser/-/my-ua-parser-2.0.4.tgz",
+      "integrity": "sha512-lhPyjoce3SRNXqgozoVti8XWC6oWY/rMcXljvov9IAgHKj2ZTU3dR5iQ7jLrIj02xD4Ggn6doTi7K2pnSbjzeg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -8937,15 +8945,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/own-keys": {
@@ -10177,12 +10176,6 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
-    },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
-      "license": "ISC"
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -13250,18 +13243,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -13647,26 +13628,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/useragent": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
-      "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
-      "license": "MIT",
-      "dependencies": {
-        "lru-cache": "4.1.x",
-        "tmp": "0.0.x"
-      }
-    },
-    "node_modules/useragent/node_modules/lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "license": "ISC",
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
       }
     },
     "node_modules/util-deprecate": {
@@ -14726,12 +14687,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-      "license": "ISC"
     },
     "node_modules/yargs-parser": {
       "version": "20.2.9",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@hapi/hapi": "21.3.12",
     "@hapi/inert": "7.1.0",
     "@hapi/jwt": "3.2.0",
-    "@hapi/scooter": "7.0.0",
+    "@hapi/scooter": "8.0.0",
     "@hapi/vision": "7.0.3",
     "@hapi/wreck": "18.1.0",
     "@hapi/yar": "11.0.2",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SFD2-973

## Summary
Upgrade the internal frontend to @hapi/scooter v8 and refresh the lockfile.

## Changes
- Bump `@hapi/scooter` to `8.0.0` in `package.json`
- Regenerate `package-lock.json`

## Testing

Checks we did to confirm this was sufficient:

- Usage audit: Searched src/ and test/ for request.plugins.scooter, request.userAgent(), useragent, semver, and .toAgent(); no direct usage or workarounds found.
- Dependency verification: Confirmed @hapi/scooter is now 8.0.0 in package.json and package-lock.json, with my-ua-parser under Scooter in the lockfile.
- Node compatibility: Verified repo engines require Node >=22 and Docker base uses latest-22, which meets Scooter v8 requirements.