### PR TITLE
FLS2-17: Update Docker Compose DAL Config

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -10,7 +10,7 @@ services:
       - ./src:/home/node/src
       - ./package.json:/home/node/package.json
 
-  kits-mock:
+  upstream-mock:
     ports:
       - '3101:3100'
     networks:
@@ -27,6 +27,12 @@ services:
       - '6380:6379'
     networks:
       - fcp-sfd
+
+  mongo:
+    networks:
+      - fcp-sfd
+    attach: false
+    command: ["--quiet"]
 
 networks:
   fcp-sfd:

--- a/compose.test.yaml
+++ b/compose.test.yaml
@@ -18,7 +18,7 @@ services:
     depends_on:
       fcp-dal-api:
         condition: service_started
-      kits-mock:
+      upstream-mock:
         condition: service_started
     volumes:
       - ./src/:/home/node/src

--- a/compose.yaml
+++ b/compose.yaml
@@ -24,18 +24,27 @@ services:
       ENTRA_REDIRECT_URL: http://localhost:3006/auth/sign-in-oidc
       ENTRA_SIGN_OUT_REDIRECT_URL: http://localhost:3006/auth/sign-out-oidc
 
-  kits-mock:
-    image: defradigital/fcp-dal-upstream-mock:0.38.0
+  upstream-mock:
+    image: defradigital/fcp-dal-upstream-mock:0.79.0
     environment:
       MOCK_LOG_LEVEL: info
       MOCK_SERVER_COLLECTION: all
       NODE_ENV: development
       PORT: 3100
+      KIT_EXT_PERSON_ID_OVERRIDE: 3000000
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:3100/health']
+      interval: 3s
+      timeout: 2s
+      retries: 5
 
   fcp-dal-api:
-    image: defradigital/fcp-dal-api:0.68.0
+    image: defradigital/fcp-dal-api:2.2.1
     depends_on:
-      - kits-mock
+      upstream-mock:
+        condition: service_healthy
+      mongo:
+        condition: service_started
     environment:
       ALL_SCHEMA_ON: true
       LOG_LEVEL: info
@@ -43,13 +52,22 @@ services:
       PORT: 3005
       ENVIRONMENT: dev
       DISABLE_AUTH: true
+      HITACHI_DISABLE_AUTH: true
       DISABLE_PROXY: true
       GRAPHQL_DASHBOARD_ENABLED: true
       ADMIN_AD_GROUP_ID: unused
-      KITS_GATEWAY_INTERNAL_URL: http://kits-mock:3100/v1/
-      KITS_GATEWAY_TIMEOUT_MS: 3006
+      KITS_INTERNAL_GATEWAY_URL: http://upstream-mock:3100/extapi/
+      KITS_EXTERNAL_GATEWAY_URL: http://upstream-mock:3100/extapi/
+      KIT_EXT_PERSON_ID_OVERRIDE: 3000000
+      KITS_GATEWAY_TIMEOUT_MS: 3000
       KITS_DISABLE_MTLS: true
-      DAL_REQUEST_TIMEOUT_MS: 3006
+      HITACHI_GATEWAY_URL: http://upstream-mock:3100/api/
+      HITACHI_TIMEOUT_MS: 3000
+      MONGO_URI: mongodb://mongo:27017
+      DAL_REQUEST_TIMEOUT_MS: 3000
 
   redis:
     image: redis:7.2.3-alpine3.18
+
+  mongo:
+    image: mongo:8.2

--- a/test/integration/narrow/dal/connector.test.js
+++ b/test/integration/narrow/dal/connector.test.js
@@ -24,7 +24,7 @@ vi.mock('../../../../src/services/DAL/token/get-token-service.js', async () => {
 const { createServer } = await import('../../../../src/server.js')
 const { config } = await import('../../../../src/config/index.js')
 
-const mockDefraIdToken =
+const mockEntraToken =
   'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJjb250YWN0SWQiOjMwMjAwMDAwMDAsInJlbGF0aW9uc2hpcHMiOlsiMzAwOTAwMDozMDA5MDAwMDE6Q2xlYW4gY29udHJvbCAtIGV4YW1wbGUgMToxOkV4dGVybmFsOjAiXSwicm9sZXMiOlsiMzAwOTAwMDpBZ2VudDozIl19.mock-signature'
 
 describe('Data access layer (DAL) connector integration', () => {
@@ -48,7 +48,7 @@ describe('Data access layer (DAL) connector integration', () => {
         sbi: '300900001',
         crn: '3020000000'
       },
-      mockDefraIdToken
+      mockEntraToken
     )
 
     expect(result.data).toBeDefined()

--- a/test/integration/narrow/dal/connector.test.js
+++ b/test/integration/narrow/dal/connector.test.js
@@ -24,6 +24,9 @@ vi.mock('../../../../src/services/DAL/token/get-token-service.js', async () => {
 const { createServer } = await import('../../../../src/server.js')
 const { config } = await import('../../../../src/config/index.js')
 
+const mockDefraIdToken =
+  'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJjb250YWN0SWQiOjMwMjAwMDAwMDAsInJlbGF0aW9uc2hpcHMiOlsiMzAwOTAwMDozMDA5MDAwMDE6Q2xlYW4gY29udHJvbCAtIGV4YW1wbGUgMToxOkV4dGVybmFsOjAiXSwicm9sZXMiOlsiMzAwOTAwMDpBZ2VudDozIl19.mock-signature'
+
 describe('Data access layer (DAL) connector integration', () => {
   let server
 
@@ -42,9 +45,10 @@ describe('Data access layer (DAL) connector integration', () => {
     const result = await dalConnector(
       exampleQuery,
       {
-        sbi: '107183280',
-        crn: '9477368292'
-      }
+        sbi: '300900001',
+        crn: '3020000000'
+      },
+      mockDefraIdToken
     )
 
     expect(result.data).toBeDefined()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FLS2-17

## Summary

Update local Docker Compose configuration to support newer DAL and kits-mock versions and align gateway routing with upstream changes. Newer DAL releases require additional environment configuration, MongoDB connectivity and gateway routing for the upstream mock, so these changes ensure the local environment starts correctly and remains compatible with current DAL dependencies.

## Changes

- Upgrade `fcp-dal-api` image to `0.116.0`
- Upgrade `fcp-dal-upstream-mock` image to `0.73.0`
- Add required DAL environment variables:
  - `KIT_EXT_PERSON_ID_OVERRIDE`
  - `KITS_INTERNAL_GATEWAY_URL`
  - `KITS_EXTERNAL_GATEWAY_URL`
- Add MongoDB service and configure `MONGO_URI` for DAL startup