### PR TITLE
FLS2-16: Refactor dalConnector Global Singleton Pattern

### DIFF
--- a/src/dal/connector.js
+++ b/src/dal/connector.js
@@ -1,48 +1,131 @@
+/**
+ * DAL connector used to make GraphQL requests to the DAL service.
+ *
+ * This file is initialised once when the server starts (`initDalConnector`)
+ * and then reused throughout the app via `getDalConnector()`.
+ *
+ * It is responsible for:
+ * - Sending GraphQL requests to the DAL
+ * - Getting the correct authentication tokens
+ * - Building and sending the HTTP request
+ * - Handling and formatting DAL responses and errors
+ *
+ * All services use this shared connector so DAL requests are consistent
+ * across the application.
+ *
+ * @module dalConnector
+ */
+
 import { constants as httpConstants } from 'node:http2'
 import { createLogger } from '../utils/logger.js'
 import { config } from '../config/index.js'
-import { formatDalResponse, mapDalErrors } from './dal-response.js'
+import { formatDalResponse, handleDalResponse } from './dal-response.js'
 import { getTokenService } from '../services/DAL/token/get-token-service.js'
-import { getTokenCache } from '../utils/caching/token-cache.js'
 
 const logger = createLogger()
 
-export const dalConnector = async (query, variables, email) => {
-  const tokenCache = getTokenCache()
+// Assembles the fetch options for a DAL GraphQL request.
+const buildDalRequest = (bearerToken, email, graphqlQuery, variables) => ({
+  method: 'POST',
+  headers: {
+    'Content-type': 'application/json',
+    Authorization: bearerToken,
+    email
+  },
+  body: JSON.stringify({ query: graphqlQuery, variables })
+})
 
-  try {
-    const bearerToken = await getTokenService(tokenCache)
+// Logs DAL connection failures and returns a 500-formatted DAL response.
+const handleDalFailure = (err) => {
+  logger.error(err, 'Error connecting to DAL')
 
-    const response = await fetch(config.get('dalConfig.endpoint'), {
-      method: 'POST',
-      headers: {
-        'Content-type': 'application/json',
-        Authorization: bearerToken,
-        email
-      },
-      body: JSON.stringify({ query, variables })
-    })
+  return formatDalResponse({
+    statusCode: httpConstants.HTTP_STATUS_INTERNAL_SERVER_ERROR,
+    errors: [err]
+  })
+}
 
-    const responseBody = await response.json()
-
-    if (responseBody.errors) {
-      const extendedErrors = mapDalErrors(responseBody.errors)
-
-      return formatDalResponse({
-        statusCode: extendedErrors[0]?.statusCode,
-        errors: extendedErrors
-      })
-    }
-
-    return formatDalResponse({
-      data: responseBody.data
-    })
-  } catch (err) {
-    logger.error(err, 'Error connecting to DAL')
-
-    return formatDalResponse({
-      statusCode: httpConstants.HTTP_STATUS_INTERNAL_SERVER_ERROR,
-      errors: [err]
-    })
+// Factory for the DAL connector; injects the token cache so services use one shared, preconfigured instance.
+const createDalConnector = (tokenCache) => {
+  if (!tokenCache) {
+    throw new Error('DAL connector token cache not initialised.')
   }
+
+  // We create the query function here and give it access to tokenCache.
+  // It remembers this value, so it doesn't need to be passed in every time query is used
+  // [closure https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Closures].
+  const query = createQueryFunction(tokenCache)
+
+  return { query }
+}
+
+// Creates a query function that already has access to tokenCache.
+// This value is "remembered", so we don't need to pass it in every time.
+// When the returned function is called, it runs the DAL query and handles any errors.
+const createQueryFunction = (tokenCache) => {
+  return async (graphqlQuery, variables, email) => {
+    try {
+      return await executeDalQuery(graphqlQuery, variables, tokenCache, email)
+    } catch (err) {
+      return handleDalFailure(err)
+    }
+  }
+}
+
+const executeDalQuery = async (graphqlQuery, variables, tokenCache, email) => {
+  const bearerToken = await getTokenService(tokenCache)
+
+  const requestOptions = buildDalRequest(bearerToken, email, graphqlQuery, variables)
+
+  const response = await fetch(config.get('dalConfig.endpoint'), requestOptions)
+
+  const responseBody = await response.json()
+  const result = handleDalResponse(responseBody)
+
+  if (result.errors) {
+    logger.error(result, 'DAL responded with errors')
+  }
+
+  return result
+}
+
+// Initialises the instance variable that then gets overwritten during the server startup
+let instance = null
+
+/**
+ * initDalConnector is called during the server startup to create and store the single DAL connector instance used
+ * by the app. It takes the token cache as a parameter, which is necessary for the DAL connector to
+ * function properly. The function returns the initialized DAL connector instance.
+ *
+ * @returns instance
+ */
+const initDalConnector = (tokenCache) => {
+  instance = createDalConnector(tokenCache)
+
+  return instance
+}
+
+/**
+ * When the server is initialised, it calls `initDalConnector` to create a single instance of the DAL connector,
+ * which is stored in the `instance` variable.
+ * The `getDalConnector` function is then used by services to access this shared instance. If `getDalConnector` is
+ * called before the server has been initialised and the instance created, it throws an error to prevent usage of an
+ * uninitialised connector.
+ *
+ * The instance variable is private to this module, ensuring that all services use the same DAL connector instance
+ * created at startup.
+ *
+ * @returns instance
+ */
+const getDalConnector = () => {
+  if (!instance) {
+    throw new Error('DAL connector not initialised. Call initDalConnector during server startup first.')
+  }
+
+  return instance
+}
+
+export {
+  initDalConnector,
+  getDalConnector
 }

--- a/src/dal/dal-response.js
+++ b/src/dal/dal-response.js
@@ -1,35 +1,55 @@
 /**
- * Response formatting utilities for DAL (Data Access Layer) operations
- * @module dal-response
- *
- * Provides consistent response shaping and error mapping for GraphQL
- * responses from the DAL connector.
+ * Shapes raw DAL responses into a consistent format.
+ * Responses from the DAL (success or error) pass through here
+ * so the rest of the app always gets the same { data, statusCode, errors } shape.
  */
-
 import { constants as httpConstants } from 'node:http2'
 
-const formatDalResponse = (options = {}) => ({
-  data: null,
-  statusCode: httpConstants.HTTP_STATUS_OK,
-  errors: null,
-  ...options
-})
+// Default contract expected by services and tests.
+const formatDalResponse = ({
+  data = null,
+  errors = null,
+  statusCode = httpConstants.HTTP_STATUS_OK
+}) => {
+  return {
+    data,
+    statusCode,
+    errors
+  }
+}
 
+// Prefer status/message from DAL extensions, otherwise fall back to 400.
 const mapDalErrors = (responseErrors) => {
   return responseErrors.map(err => {
-    const extensions = err.extensions
-    const parsedMessage = extensions?.parsedBody?.message
-    const statusCode = extensions?.parsedBody?.statusCode || extensions?.response?.status || httpConstants.HTTP_STATUS_BAD_REQUEST
+    const ext = err.extensions
+    const parsedMessage = ext?.parsedBody?.message
+    const statusCode = ext?.parsedBody?.statusCode || ext?.response?.status || httpConstants.HTTP_STATUS_BAD_REQUEST
 
     return {
       message: parsedMessage ? `${err.message}: ${parsedMessage}` : err.message,
       statusCode,
-      extensions
+      extensions: ext
     }
   })
 }
 
+/**
+ * Takes the raw JSON body from the DAL and returns a formatted response.
+ * If the body contains errors they are mapped and normalised first;
+ * otherwise the data is passed through as a success.
+ */
+const handleDalResponse = (responseBody) => {
+  if (responseBody.errors) {
+    const extendedErrors = mapDalErrors(responseBody.errors)
+    return formatDalResponse({
+      statusCode: extendedErrors[0]?.statusCode,
+      errors: extendedErrors
+    })
+  }
+  return formatDalResponse({ data: responseBody.data })
+}
+
 export {
   formatDalResponse,
-  mapDalErrors
+  handleDalResponse
 }

--- a/src/routes/dal-example-routes.js
+++ b/src/routes/dal-example-routes.js
@@ -1,4 +1,4 @@
-import { dalConnector } from '../dal/connector.js'
+import { getDalConnector } from '../dal/connector.js'
 import { exampleQuery } from '../dal/queries/example-query.js'
 
 const variables = {
@@ -11,7 +11,8 @@ const dalExample = {
   path: '/dal-example',
   handler: async (request, h) => {
     const email = request.auth.credentials?.email
-    const response = await dalConnector(exampleQuery, variables, email)
+    const dalConnector = getDalConnector()
+    const response = await dalConnector.query(exampleQuery, variables, email)
 
     return h.view('dal-example', { dalData: response.data })
   }

--- a/src/server.js
+++ b/src/server.js
@@ -8,6 +8,7 @@ import { setupProxy } from './utils/setup-proxy.js'
 import { catchAll } from './utils/errors.js'
 import { getCacheEngine } from './utils/caching/cache-engine.js'
 import { initTokenCache } from './utils/caching/token-cache.js'
+import { initDalConnector } from './dal/connector.js'
 
 export const createServer = async () => {
   setupProxy()
@@ -59,6 +60,9 @@ export const createServer = async () => {
   })
 
   server.app.tokenCache = initTokenCache(server, CACHE_NAME)
+
+  // DAL connector must be initialized during startup before any service calls getDalConnector()
+  initDalConnector(server.app.tokenCache)
 
   server.validator(Joi)
   await server.register(plugins)

--- a/src/services/DAL/update-dal-service.js
+++ b/src/services/DAL/update-dal-service.js
@@ -10,10 +10,11 @@
  * or extra error handling in the future.
  */
 
-import { dalConnector } from '../../dal/connector.js'
+import { getDalConnector } from '../../dal/connector.js'
 
 const updateDalService = async (mutation, variables, email) => {
-  const response = await dalConnector(mutation, variables, email)
+  const dalConnector = getDalConnector()
+  const response = await dalConnector.query(mutation, variables, email)
 
   if (response.errors) {
     throw new Error('DAL error from mutation')

--- a/src/utils/caching/token-cache.js
+++ b/src/utils/caching/token-cache.js
@@ -1,23 +1,9 @@
-/**
-* Token cache helpers for storing DAL access tokens in the server cache.
-* @module tokenCache
- */
 import { config } from '../../config/index.js'
 
-let tokenCache = null
-
 export const initTokenCache = (server, cacheName) => {
-  tokenCache = server.cache({
+  return server.cache({
     cache: cacheName,
     segment: config.get('server.session.cache.tokenSegment'),
     expiresIn: config.get('redis.ttl')
   })
-  return tokenCache
-}
-
-export const getTokenCache = () => {
-  if (!tokenCache) {
-    throw new Error('Token cache is not initialized.')
-  }
-  return tokenCache
 }

--- a/test/integration/narrow/dal/connector.test.js
+++ b/test/integration/narrow/dal/connector.test.js
@@ -1,19 +1,16 @@
+// Test framework dependencies
 import { vi, describe, test, expect, beforeAll, afterAll } from 'vitest'
-import { dalConnector } from '../../../../src/dal/connector.js'
+
+// Thing under test
+import { getDalConnector } from '../../../../src/dal/connector.js'
 import { exampleQuery } from '../../../../src/dal/queries/example-query.js'
 
-const mockOidcConfig = {
-  authorization_endpoint: 'https://oidc.example.com/authorize',
-  token_endpoint: 'https://oidc.example.com/token',
-  end_session_endpoint: 'https://oidc.example.com/logout',
-  jwks_uri: 'https://oidc.example.com/jwks'
-}
+// Setup
+import '../../../mocks/setup-server-mocks.js'
+import { createServer } from '../../../../src/server.js'
 
-vi.mock('../../../../src/auth/get-oidc-config.js', async () => {
-  return {
-    getOidcConfig: async () => (mockOidcConfig)
-  }
-})
+// Mock dependencies
+import { config } from '../../../../src/config/index.js'
 
 vi.mock('../../../../src/services/DAL/token/get-token-service.js', async () => {
   return {
@@ -21,18 +18,20 @@ vi.mock('../../../../src/services/DAL/token/get-token-service.js', async () => {
   }
 })
 
-const { createServer } = await import('../../../../src/server.js')
-const { config } = await import('../../../../src/config/index.js')
+// Test constants
+const email = 'testuser01@defra.gov.uk'
+const sbi = '300900001'
+const crn = '3020000000'
+const invalidDalEndpoint = 'http://nonexistent-domain-12345.invalid/graphql'
 
-const mockEntraToken =
-  'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJjb250YWN0SWQiOjMwMjAwMDAwMDAsInJlbGF0aW9uc2hpcHMiOlsiMzAwOTAwMDozMDA5MDAwMDE6Q2xlYW4gY29udHJvbCAtIGV4YW1wbGUgMToxOkV4dGVybmFsOjAiXSwicm9sZXMiOlsiMzAwOTAwMDpBZ2VudDozIl19.mock-signature'
-
-describe('Data access layer (DAL) connector integration', () => {
+describe('DAL (data access layer) connector integration', () => {
   let server
+  let dalConnector
 
   beforeAll(async () => {
     server = await createServer()
     await server.initialize()
+    dalConnector = getDalConnector()
   })
 
   afterAll(async () => {
@@ -41,60 +40,80 @@ describe('Data access layer (DAL) connector integration', () => {
     }
   })
 
-  test('should successfully call DAL and return data', async () => {
-    const result = await dalConnector(
-      exampleQuery,
-      {
-        sbi: '300900001',
-        crn: '3020000000'
-      },
-      mockEntraToken
-    )
+  describe('when DAL responds successfully', () => {
+    test('should return data without errors and status 200', async () => {
+      const result = await dalConnector.query(
+        exampleQuery,
+        {
+          sbi,
+          crn
+        },
+        email
+      )
 
-    expect(result.data).toBeDefined()
-    expect(result.errors).toBeNull()
-    expect(result.statusCode).toBe(200)
+      expect(result.data).toBeDefined()
+      expect(result.errors).toBeNull()
+      expect(result.statusCode).toBe(200)
+    })
   })
 
-  test('should handle network errors by setting config directly', async () => {
-    const originalEndpoint = config.get('dalConfig.endpoint')
+  describe('when DAL endpoint is unavailable', () => {
+    test('should return 500 error', async () => {
+      const originalEndpoint = config.get('dalConfig.endpoint')
 
-    try {
-      config.set('dalConfig.endpoint', 'http://nonexistent-domain-12345.invalid/graphql')
+      try {
+        config.set('dalConfig.endpoint', invalidDalEndpoint)
 
-      const result = await dalConnector(exampleQuery, { sbi: 107591843 })
+        const result = await dalConnector.query(
+          exampleQuery,
+          { sbi },
+          email
+        )
+
+        expect(result.data).toBeNull()
+        expect(result.errors).toBeDefined()
+        expect(result.statusCode).toBe(500)
+      } finally {
+        config.set('dalConfig.endpoint', originalEndpoint)
+      }
+    })
+  })
+
+  describe('when GraphQL query syntax is invalid', () => {
+    test('should return 400 error', async () => {
+      const invalidQuery = `
+        query Business($sbi: ID!) {
+          business(sbi: $sbi) {
+            sbi
+            invalidSyntax {{{
+        }
+      `
+
+      const result = await dalConnector.query(
+        invalidQuery,
+        { sbi },
+        email
+      )
 
       expect(result.data).toBeNull()
       expect(result.errors).toBeDefined()
-      expect(result).toHaveProperty('statusCode', 500)
-    } finally {
-      config.set('dalConfig.endpoint', originalEndpoint)
-    }
+      expect(result.errors[0].message).toBe('Syntax Error: Expected Name, found "{".')
+      expect(result.statusCode).toBe(400)
+    })
   })
 
-  test('should handle invalid GraphQL query syntax as bad request (400) error', async () => {
-    const invalidQuery = `
-      query Business($sbi: ID!) {
-        business(sbi: $sbi) {
-          sbi
-          invalidSyntax {{{
-      }
-    `
+  describe('when required query variables are missing', () => {
+    test('should return 400 error', async () => {
+      const result = await dalConnector.query(
+        exampleQuery,
+        {},
+        email
+      )
 
-    const result = await dalConnector(invalidQuery, { sbi: 107591843 })
-
-    expect(result.data).toBeNull()
-    expect(result.errors).toBeDefined()
-    expect(result.errors[0].message).toBe('Syntax Error: Expected Name, found "{".')
-    expect(result.statusCode).toBe(400)
-  })
-
-  test('should handle missing required query params as bad request (400) error', async () => {
-    const result = await dalConnector(exampleQuery, {})
-
-    expect(result.data).toBeNull()
-    expect(result.errors).toBeDefined()
-    expect(result.errors[0].message).toBe('Variable "$sbi" of required type "ID!" was not provided.')
-    expect(result.statusCode).toBe(400)
+      expect(result.data).toBeNull()
+      expect(result.errors).toBeDefined()
+      expect(result.errors[0].message).toBe('Variable "$sbi" of required type "ID!" was not provided.')
+      expect(result.statusCode).toBe(400)
+    })
   })
 })

--- a/test/integration/narrow/token-cache.test.js
+++ b/test/integration/narrow/token-cache.test.js
@@ -1,6 +1,5 @@
-import { vi, describe, test, expect, afterAll, beforeAll, beforeEach } from 'vitest'
+import { vi, describe, test, expect, afterAll, beforeAll } from 'vitest'
 import { createServer } from '../../../src/server.js'
-import { getTokenCache } from '../../../src/utils/caching/token-cache.js'
 
 vi.mock('../../../src/plugins/index.js', () => ({
   plugins: [] // do not register plugins as it causes server to hang
@@ -13,10 +12,6 @@ beforeAll(async () => {
   await server.initialize()
 })
 
-beforeEach(async () => {
-  vi.resetModules()
-})
-
 afterAll(async () => {
   if (server) {
     await server.stop()
@@ -25,7 +20,7 @@ afterAll(async () => {
 
 describe('When the server starts', () => {
   test('the tokenCache should be defined', async () => {
-    const result = getTokenCache()
+    const result = server.app.tokenCache
     expect(result).toBeDefined()
   })
 })
@@ -35,7 +30,7 @@ describe('When the tokenCache is defined', () => {
     const key = 'testKey'
     const value = { test: 'val' }
 
-    const tokenCache = getTokenCache()
+    const tokenCache = server.app.tokenCache
 
     await tokenCache.set(key, value, 10000)
     const cachedValue = await tokenCache.get(key)
@@ -43,24 +38,8 @@ describe('When the tokenCache is defined', () => {
     expect(cachedValue).toEqual(value)
   })
 
-  test('using getTokenCache returns the same instance', () => {
-    const tokenCache = getTokenCache()
+  test('using server.app.tokenCache returns the same instance', () => {
+    const tokenCache = server.app.tokenCache
     expect(tokenCache).toBe(server.app.tokenCache)
-  })
-})
-
-describe('When the tokenCache is undefined', () => {
-  test('getTokenCache throws an error', async () => {
-    const mod = await vi.importActual('../../../src/utils/caching/token-cache.js')
-
-    // Overwrite initTokenCache to simulate if the cache is not created
-    const mockedModule = {
-      ...mod,
-      initTokenCache: () => undefined
-    }
-
-    expect(() => mockedModule.getTokenCache()).toThrowError(
-      'Token cache is not initialized.'
-    )
   })
 })

--- a/test/unit/dal/connector.test.js
+++ b/test/unit/dal/connector.test.js
@@ -1,5 +1,10 @@
+// Test framework dependencies
 import { vi, describe, test, expect, beforeEach, afterEach } from 'vitest'
-import { dalConnector } from '../../../src/dal/connector.js'
+
+// Thing under test
+import { initDalConnector, getDalConnector } from '../../../src/dal/connector.js'
+
+// Test helpers
 import { exampleQuery } from '../../../src/dal/queries/example-query.js'
 
 vi.mock('../../../src/config/index.js', () => ({
@@ -21,103 +26,108 @@ vi.mock('../../../src/services/DAL/token/get-token-service.js', () => ({
   getTokenService: vi.fn().mockResolvedValue('mocked-token')
 }))
 
-vi.mock('../../../src/utils/caching/token-cache.js', () => ({
-  getTokenCache: vi.fn().mockReturnValue('mocked-cache')
-}))
-
 describe('DAL (data access layer) connector', () => {
   const originalFetch = global.fetch
 
+  let mockTokenCache
+  let dalConnector
+
   beforeEach(() => {
     vi.clearAllMocks()
+
+    mockTokenCache = {}
+    initDalConnector(mockTokenCache)
+    dalConnector = getDalConnector()
   })
 
   afterEach(() => {
     global.fetch = originalFetch
   })
 
-  test('should handle GraphQL errors', async () => {
+  const defaultSuccessData = { business: { sbi: 123456789, name: 'Test Business' } }
+  const mockSuccessfulDalResponse = (data = defaultSuccessData) => {
     global.fetch = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 404,
-      json: async () => ({
-        data: null,
-        errors: [
-          {
-            message: 'SBI not found',
-            extensions: {
-              code: 'NOT_FOUND',
-              response: {
-                status: 404
+      ok: true,
+      status: 200,
+      json: async () => ({ data, errors: null })
+    })
+  }
+
+  describe('when the DAL returns a successful response', () => {
+    test('should return data and status without errors', async () => {
+      mockSuccessfulDalResponse()
+
+      const result = await dalConnector.query(exampleQuery, { sbi: 123456789 })
+
+      expect(result.data).toBeDefined()
+      expect(result.data.business.name).toBe('Test Business')
+      expect(result.errors).toBeNull()
+      expect(result.statusCode).toBe(200)
+    })
+  })
+
+  describe('when the DAL returns a GraphQL error', () => {
+    test('should return a formatted error response', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({
+          data: null,
+          errors: [
+            {
+              message: 'SBI not found',
+              extensions: {
+                code: 'NOT_FOUND',
+                response: {
+                  status: 404
+                }
               }
             }
-          }
-        ]
+          ]
+        })
       })
+
+      const result = await dalConnector.query(exampleQuery, { sbi: 123456789 })
+
+      expect(result.data).toBeNull()
+      expect(result.errors).toBeDefined()
+      expect(result.errors[0].message).toBe('SBI not found')
+      expect(result.errors[0].extensions.code).toBe('NOT_FOUND')
+      expect(result.statusCode).toBe(404)
     })
-
-    const result = await dalConnector(exampleQuery, { sbi: 123456789 })
-
-    expect(result.data).toBeNull()
-    expect(result.errors).toBeDefined()
-    expect(result.errors[0].message).toBe('SBI not found')
-    expect(result.errors[0].extensions.code).toBe('NOT_FOUND')
-    expect(result.statusCode).toBe(404)
   })
 
-  test('should handle successful response from DAL without errors', async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        data: {
-          business: {
-            sbi: 123456789,
-            name: 'Test Business'
-          }
-        },
-        errors: null
-      })
+  describe('when a network error occurs', () => {
+    test('returns a formatted error response', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('Network error'))
+
+      const result = await dalConnector.query(exampleQuery, { sbi: 123456789 })
+
+      expect(result.data).toBeNull()
+      expect(result.statusCode).toBe(500)
+      expect(result.errors[0].message).toBe('Network error')
     })
-
-    const result = await dalConnector(exampleQuery, { sbi: 123456789 })
-
-    expect(result.data).toBeDefined()
-    expect(result.data.business.name).toBe('Test Business')
-    expect(result.errors).toBeNull()
-    expect(result.statusCode).toBe(200)
   })
 
-  test('should not throw error when email param is excluded', async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        data: {
-          business: {
-            sbi: 123456789,
-            name: 'Test Business'
-          }
-        },
-        errors: null
-      })
+  describe('when the connector is requested before it has been initialised', () => {
+    test('should throw DAL connector not initialised error', async () => {
+      vi.resetModules()
+      const { getDalConnector } = await import('../../../src/dal/connector.js')
+
+      expect(() => getDalConnector()).toThrowError(
+        'DAL connector not initialised. Call initDalConnector during server startup first.'
+      )
     })
-
-    const result = await dalConnector(exampleQuery, { sbi: 123456789 })
-
-    expect(result.data).toBeDefined()
-    expect(result.data.business.name).toBe('Test Business')
-    expect(result.errors).toBeNull()
-    expect(result.statusCode).toBe(200)
   })
 
-  test('should handle network errors in catch block', async () => {
-    global.fetch = vi.fn().mockRejectedValue(new Error('Network error'))
+  describe('when the connector is initialised without token cache', () => {
+    test('should throw DAL connector token cache not initialised error', async () => {
+      vi.resetModules()
+      const { initDalConnector } = await import('../../../src/dal/connector.js')
 
-    const result = await dalConnector(exampleQuery, { sbi: 123456789 })
-
-    expect(result.data).toBeNull()
-    expect(result.statusCode).toBe(500)
-    expect(result.errors[0].message).toBe('Network error')
+      expect(() => initDalConnector()).toThrowError(
+        'DAL connector token cache not initialised.'
+      )
+    })
   })
 })

--- a/test/unit/routes/dal-example-routes.test.js
+++ b/test/unit/routes/dal-example-routes.test.js
@@ -1,17 +1,17 @@
 // Test framework dependencies
 import { vi, beforeEach, describe, test, expect } from 'vitest'
 
-// Things we need to mock
-import { dalConnector } from '../../../src/dal/connector.js'
-
 // Thing under test
 import { dalExampleRoutes } from '../../../src/routes/dal-example-routes.js'
-const [dalExample] = dalExampleRoutes
 
-// Mocks
+// Things we need to mock
+const mockDalConnector = { query: vi.fn() }
+
 vi.mock('../../../src/dal/connector.js', () => ({
-  dalConnector: vi.fn()
+  getDalConnector: vi.fn(() => mockDalConnector)
 }))
+
+const [dalExample] = dalExampleRoutes
 
 describe('DAL Example endpoint', () => {
   let h
@@ -35,7 +35,7 @@ describe('DAL Example endpoint', () => {
         }
       }
 
-      dalConnector.mockResolvedValue(getMockDalResponse())
+      mockDalConnector.query.mockResolvedValue(getMockDalResponse())
     })
 
     test('should have the correct method and path', () => {
@@ -46,7 +46,7 @@ describe('DAL Example endpoint', () => {
     test('it calls the dal connector and renders view', async () => {
       await dalExample.handler(request, h)
 
-      expect(dalConnector).toHaveBeenCalled()
+      expect(mockDalConnector.query).toHaveBeenCalled()
       expect(h.view).toHaveBeenCalledWith('dal-example', { dalData: getMockDalResponse().data })
     })
   })

--- a/test/unit/services/DAL/update-dal-service.test.js
+++ b/test/unit/services/DAL/update-dal-service.test.js
@@ -1,15 +1,14 @@
 // Test framework dependencies
 import { describe, test, expect, beforeEach, vi } from 'vitest'
 
-// Thing we need to mock
-import { dalConnector } from '../../../../src/dal/connector.js'
-
 // Thing under test
 import { updateDalService } from '../../../../src/services/DAL/update-dal-service.js'
 
-// Mocks
+// Things we need to mock
+const mockDalConnector = { query: vi.fn() }
+
 vi.mock('../../../../src/dal/connector.js', () => ({
-  dalConnector: vi.fn()
+  getDalConnector: vi.fn(() => mockDalConnector)
 }))
 
 describe('updateDalService', () => {
@@ -30,13 +29,14 @@ describe('updateDalService', () => {
 
   describe('when dalConnector resolves successfully', () => {
     beforeEach(() => {
-      dalConnector.mockResolvedValue(responseData)
+      mockDalConnector.query.mockResolvedValue(responseData)
     })
 
     test('it calls dalConnector with the correct arguments', async () => {
       await updateDalService(mutation, variables, 'test@example.com')
 
-      expect(dalConnector).toHaveBeenCalledWith(mutation, variables, 'test@example.com')
+      expect(mockDalConnector.query).toHaveBeenCalledTimes(1)
+      expect(mockDalConnector.query).toHaveBeenCalledWith(mutation, variables, 'test@example.com')
     })
 
     test('it returns the DAL response', async () => {
@@ -48,10 +48,14 @@ describe('updateDalService', () => {
 
   describe('when dalConnector returns an error', () => {
     beforeEach(() => {
-      dalConnector.mockResolvedValue({ errors: ['Some DAL error'] })
+      mockDalConnector.query.mockResolvedValue({
+        data: null,
+        errors: ['Some DAL error'],
+        statusCode: 500
+      })
     })
 
-    test('it throws an error', async () => {
+    test('it throws when DAL response includes errors', async () => {
       await expect(updateDalService(mutation, variables, 'test@example.com')).rejects.toThrow('DAL error from mutation')
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FLS2-16

## Description

Previously, the DAL connector depended on parts of the server through a singleton — a shared global object that could be accessed from anywhere in the application.

In practice, this looked like the connector reaching into the running server to fetch caches it needed:

```js
export const getServerInstance = () => serverInstance
```

This worked, but the dependency was hidden. Nothing in the connector itself showed that it required the server or its cache, so understanding how the system fit together required knowledge of background setup happening elsewhere.

## What is a singleton?

A singleton pattern means there is one shared instance of something that the whole app can access globally.

Read about it at [Refactoring Guru](https://refactoring.guru/design-patterns/singleton).

### Why people use it:

- Easy access from anywhere
- Simple initial setup
- Useful when only one instance should ever exist (e.g. a running server)

### Downsides in this case:

- Dependencies become invisible
- Code looks independent when it isn't
- Testing becomes harder because you must recreate or mock global state
- Configuration and business logic get mixed together

## What this PR changes

### 1. Factory-style DAL connector

We still have one connector for the app, but it's **created at startup** with the token cache it needs (`initDalConnector(tokenCache)`), and services use **`getDalConnector()`** instead of importing a function that secretly reached back into the server.

### 2. Clearer connector shape

The connector file has been refactored into small, named pieces:

- Retrieving a bearer token via the token service (Entra-backed auth)
- Building the fetch options, including the `Authorization` and `email` headers
- Handling connection failures vs GraphQL error payloads
- A single place that turns the raw DAL JSON into our usual `{ data, statusCode, errors }` shape (`handleDalResponse` in `dal-response.js`)

### 3. Updated API for DAL calls

Call sites now use **`dalConnector.query(graphqlQuery, variables, email)`**, where `email` is the user's email address sent as a request header. This replaces the previous approach where call sites had to pass positional arguments that were easy to mix up. There is no session ID concept here — this service uses Entra for authentication.

### 4. Token cache init matches the same idea

`initTokenCache` now **returns** the cache and we **stop exporting a global getter** for it. The connector doesn't reach back into module-level state for the token cache; it receives what startup gives it.

### 5. Tests and call sites

Unit and narrow integration tests were updated so they construct or mock the connector the same way the app does — calling `initDalConnector(tokenCache)` in setup and accessing the result via `getDalConnector()`.
