### PR TITLE
Add local DAL upstream mock Docker Compose configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ DAL_CLIENT_ID=long-value-full-of-numbers-and-letters-in-lowercase
 DAL_CLIENT_SECRET=longvaluefullofnumbersandlettersandsymbols
 DAL_TENANT_ID=long-value-full-of-numbers-and-letters-in-lowercase
 
+# Local DAL upstream mock (optional). Required for the "DAL upstream mock" task.
+DAL_UPSTREAM_MOCK_LOCAL_PATH=/path/to/fcp-dal-upstream-mock
+
 # Entra config
 ENTRA_WELL_KNOWN_URL=https://entra.well-known/url
 ENTRA_TENANT_ID=long-value-full-of-numbers-and-letters-in-lowercase

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If you need to modify mock responses or the upstream deployed environments are u
    npm run docker:dal-local
    ```
 
-> **Note:** a VS Code task for running the local mock is provided by [`fcp-sfd-dev-environment`](https://github.com/DEFRA/fcp-sfd-dev-environment) — see the **🧪🔧 Run with local DAL mock** task.
+> **Note:** a VS Code task for running the local mock is provided by [`fcp-sfd-dev-environment`](https://github.com/DEFRA/fcp-sfd-dev-environment) — see the **🧪🔧 Up Frontend internal with local DAL mock** task.
 
 ### Accessing the application
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can either run this service independently or alternatively run the [fcp-sfd-
 
 ### Building the Docker image
 
-Container images are built using Docker Compose. It's important to note that in order to successfully run the [fcp-dal-api](https://github.com/defra/fcp-dal-api) and its [upstream-mock](https://github.com/defra/fcp-dal-upstream-mock) to interact with the Data Access Layer (DAL), you _must_ run this service as a Docker container. This is because the [Docker Compose configuration](./compose.yaml) for this repository pulls and runs the Docker images for the `fcp-dal-api` and `fcp-dal-upstream-mock` (a.k.a. the `kits-mock`) from the Docker registry.
+Container images are built using Docker Compose. It's important to note that in order to successfully run the [fcp-dal-api](https://github.com/defra/fcp-dal-api) and its [upstream-mock](https://github.com/defra/fcp-dal-upstream-mock) to interact with the Data Access Layer (DAL), you _must_ run this service as a Docker container. This is because the [Docker Compose configuration](./compose.yaml) for this repository pulls and runs the Docker images for the `fcp-dal-api` and `fcp-dal-upstream-mock` (a.k.a. the DAL or Kits mock) from the Docker registry.
 
 First, build the Docker image:
 ```
@@ -47,6 +47,25 @@ docker compose up
 Use the `-d` at the end of the above command to run in detached mode e.g. if you wish to view logs in another application such as Docker Desktop.
 
 You can find further information on how SFD integrates with the DAL on [Confluence](https://eaflood.atlassian.net/wiki/spaces/SFD/pages/5712838853/Single+Front+Door+Integration+with+Data+Access+Layer).
+
+### Running with a local upstream mock
+
+If you need to modify mock responses or the upstream deployed environments are unavailable, you can build `fcp-dal-upstream-mock` from a local checkout instead of using the published Docker image.
+
+1. Clone the upstream mock repository:
+   ```
+   git clone https://github.com/DEFRA/fcp-dal-upstream-mock.git
+   ```
+2. Add the path to your `.env` file:
+   ```
+   DAL_UPSTREAM_MOCK_LOCAL_PATH=/path/to/fcp-dal-upstream-mock
+   ```
+3. Start the stack using the local mock:
+   ```
+   npm run docker:dal-local
+   ```
+
+> **Note:** a VS Code task for running the local mock is provided by [`fcp-sfd-dev-environment`](https://github.com/DEFRA/fcp-sfd-dev-environment) — see the **🧪🔧 Run with local DAL mock** task.
 
 ### Accessing the application
 

--- a/compose.dal-local.yaml
+++ b/compose.dal-local.yaml
@@ -10,6 +10,3 @@ services:
     command: ["node", "src"]
     healthcheck:
       test: ['CMD', 'wget', '-qO-', 'http://127.0.0.1:3100/health']
-  fcp-dal-api:
-    environment:
-      KITS_GATEWAY_INTERNAL_URL: http://upstream-mock:3100/extapi/

--- a/compose.dal-local.yaml
+++ b/compose.dal-local.yaml
@@ -1,0 +1,15 @@
+services:
+  fcp-sfd-frontend-internal:
+    environment:
+      DAL_ENDPOINT: http://fcp-dal-api:3005/graphql
+  upstream-mock:
+    image: fcp-dal-upstream-mock:local
+    build:
+      context: ${DAL_UPSTREAM_MOCK_LOCAL_PATH}
+      target: development
+    command: ["node", "src"]
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://127.0.0.1:3100/health']
+  fcp-dal-api:
+    environment:
+      KITS_GATEWAY_INTERNAL_URL: http://upstream-mock:3100/extapi/

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "pretest": "npm run test:lint",
     "docker:debug": "docker compose -f compose.yaml -f compose.debug.yaml -p \"fcp-sfd-frontend-internal\" up",
     "docker:dev": "docker compose up",
+    "docker:dal-local": "docker compose -f compose.yaml -f compose.override.yaml -f compose.dal-local.yaml up --build",
     "docker:test": "npm run lint && mkdir -p coverage 2>/dev/null || true docker compose -p fcp-sfd-frontend-internal-test down -v && docker compose -f compose.yaml -f compose.test.yaml -p fcp-sfd-frontend-internal-test run --build --rm fcp-sfd-frontend-internal",
     "docker:test:watch": "docker compose -p fcp-sfd-frontend-internal-test down -v && docker compose -f compose.yaml -f compose.test.yaml -f compose.test.watch.yaml -p fcp-sfd-frontend-internal-test run --build --rm fcp-sfd-frontend-internal",
     "test": "rm -rf ./coverage/** && vitest run --coverage",


### PR DESCRIPTION
## Summary

When the upstream deployed environments are unavailable, or when mock responses need to be modified locally, there was no straightforward way to build and run `fcp-dal-upstream-mock` from a local checkout in `fcp-sfd-frontend-internal`. This adds the tooling to support that workflow, mirroring what already exists in `fcp-sfd-frontend`.

## Changes

- Add `compose.dal-local.yaml` — Docker Compose override that builds `fcp-dal-upstream-mock` from a local path (`DAL_UPSTREAM_MOCK_LOCAL_PATH`) rather than the published image
- Add `docker:dal-local` npm script — runs the stack with the local mock override applied
- Update `.env.example` — document the `DAL_UPSTREAM_MOCK_LOCAL_PATH` variable
- Update `README.md` — add a "Running with a local upstream mock" section with step-by-step instructions and a note pointing to the VS Code task in `fcp-sfd-dev-environment`