### PR TITLE
FLS2-34: A user can search by CRN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@defra/fcp-sfd-frontend-engine": "0.2.5",
+        "@defra/fcp-sfd-frontend-engine": "0.2.8",
         "@defra/hapi-tracing": "1.30.0",
         "@elastic/ecs-pino-format": "1.5.0",
         "@hapi/bell": "13.1.0",
@@ -348,12 +348,48 @@
       "license": "MIT"
     },
     "node_modules/@defra/fcp-sfd-frontend-engine": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.2.5.tgz",
-      "integrity": "sha512-1zuiLug1D1UgmbpVthRcLa0Cv7grl/QhJ7VbieT2kxouf7NSaW+zEUfqx3sLfDrxDRBOYf8qw3qmKQQ0aeGwFg==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.2.8.tgz",
+      "integrity": "sha512-DjBXVJ8RLpAvbpOlYXFNvpZwbWECnnQqFAirNuVHovzKx0pbMxw53iJPHIbDOLb/iWNLVeC0X2FS5o5KpHIN9A==",
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "joi": "17.13.3"
+        "joi": "18.2.1"
+      }
+    },
+    "node_modules/@defra/fcp-sfd-frontend-engine/node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@defra/fcp-sfd-frontend-engine/node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@defra/fcp-sfd-frontend-engine/node_modules/joi": {
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
+      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@defra/hapi-tracing": {
@@ -1497,6 +1533,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.6.tgz",
+      "integrity": "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@hapi/topo": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
@@ -2581,6 +2626,12 @@
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@stylistic/eslint-plugin": {
       "version": "2.11.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "license": "OGL-UK-3.0",
   "dependencies": {
-    "@defra/fcp-sfd-frontend-engine": "0.2.5",
+    "@defra/fcp-sfd-frontend-engine": "0.2.8",
     "@defra/hapi-tracing": "1.30.0",
     "@elastic/ecs-pino-format": "1.5.0",
     "@hapi/bell": "13.1.0",

--- a/src/dal/queries/customer-details-by-crn.js
+++ b/src/dal/queries/customer-details-by-crn.js
@@ -1,0 +1,31 @@
+export const customerDetailsByCrn = `
+  query Customer($crn: ID!) {
+  customer(crn: $crn) {
+    crn
+    info {
+      name {
+        first
+        last
+      }
+      address {
+        buildingNumberRange
+        buildingName
+        flatName
+        street
+        city
+        county
+        postalCode
+        country
+        dependentLocality
+        doubleDependentLocality
+        line1
+        line2
+        line3
+        line4
+        line5
+        uprn
+      }
+    }
+  }
+}
+`

--- a/src/mappers/customer-details-by-crn-mapper.js
+++ b/src/mappers/customer-details-by-crn-mapper.js
@@ -1,0 +1,41 @@
+/**
+ * Takes the raw customer details by CRN data and maps it to a more usable format
+ *
+ * @param {Object} value - The data from the DAL
+ *
+ * @returns {Object} Formatted customer details data
+ */
+
+export const mapCustomerDetailsByCrn = (value) => {
+  const info = value?.customer?.info ?? {}
+  const address = info?.address ?? {}
+
+  return {
+    info: {
+      crn: value.customer.crn,
+      customerName: `${info.name.first} ${info.name.last}`
+    },
+    address: {
+      lookup: {
+        buildingNumberRange: address.buildingNumberRange,
+        flatName: address.flatName,
+        buildingName: address.buildingName,
+        dependentLocality: address.dependentLocality,
+        doubleDependentLocality: address.doubleDependentLocality,
+        street: address.street,
+        county: address.county,
+        uprn: address.uprn
+      },
+      manual: {
+        line1: address.line1,
+        line2: address.line2,
+        line3: address.line3,
+        line4: address.line4,
+        line5: address.line5
+      },
+      city: address.city,
+      postcode: address.postalCode,
+      country: address.country
+    }
+  }
+}

--- a/src/mappers/customer-details-by-crn-mapper.js
+++ b/src/mappers/customer-details-by-crn-mapper.js
@@ -8,12 +8,13 @@
 
 export const mapCustomerDetailsByCrn = (value) => {
   const info = value?.customer?.info ?? {}
+  const name = info?.name ?? {}
   const address = info?.address ?? {}
 
   return {
     info: {
       crn: value.customer.crn,
-      customerName: `${info.name.first} ${info.name.last}`
+      customerName: `${name.first} ${name.last}`
     },
     address: {
       lookup: {

--- a/src/presenters/base-presenter.js
+++ b/src/presenters/base-presenter.js
@@ -1,0 +1,64 @@
+/**
+ * Base presenter for formatting data for display
+ */
+
+/**
+ * Formats an address object into a comma-separated address string and a separate postcode.
+ *
+ * If the address contains a UPRN, the user selected it from an address lookup.
+ * Otherwise it is treated as a manually entered address.
+ *
+ * The postcode is always returned separately so views can render it on its own line.
+ *
+ * @param {Object} address - The address object from the mapped DAL response
+ *
+ * @returns {{ addressLines: string, postcode: string }}
+ */
+export const formatAddressLines = (address) => {
+  if (!address) {
+    return { addressLines: '', postcode: '' }
+  }
+
+  const lookup = address.lookup || {}
+  const manual = address.manual || {}
+  const postcode = address.postcode || ''
+  const country = address.country || ''
+  const city = address.city || ''
+
+  let lines = []
+
+  if (lookup.uprn) {
+    // The user selected an address from the lookup tool
+    const buildingAndStreet = [lookup.buildingNumberRange, lookup.street]
+      .filter(Boolean)
+      .join(' ')
+
+    lines = [
+      lookup.pafOrganisationName,
+      lookup.flatName,
+      lookup.buildingName,
+      buildingAndStreet,
+      lookup.doubleDependentLocality,
+      lookup.dependentLocality,
+      city,
+      lookup.county,
+      country
+    ]
+  } else {
+    // The user typed their address in manually
+    lines = [
+      manual.line1,
+      manual.line2,
+      manual.line3,
+      city,
+      manual.line4, // County
+      manual.line5,
+      country
+    ]
+  }
+
+  return {
+    addressLines: lines.filter(Boolean).join(', '),
+    postcode: postcode || ''
+  }
+}

--- a/src/presenters/search/search-crn-presenter.js
+++ b/src/presenters/search/search-crn-presenter.js
@@ -1,0 +1,74 @@
+/**
+ * Formats data ready for presenting in the `/search-crn` page
+ * @module searchCrnPresenter
+ */
+
+const searchCrnPresenter = (customerDetails, payload) => {
+  const { addressLines, postcode } = getFormattedAddress(customerDetails?.address)
+  const resultText = customerDetails ? `1 result for "${payload}"` : '0 results'
+
+  return {
+    customerName: customerDetails?.info?.customerName || '',
+    customerAddress: addressLines,
+    customerPostcode: postcode,
+    resultText,
+    showResults: true,
+    showCustomerDetails: Boolean(customerDetails),
+    showClear: true,
+    crn: payload ?? ''
+  }
+}
+
+// Returns the address lines as a single string and the postcode separately.
+// The view renders postcode on its own line beneath the rest of the address.
+const getFormattedAddress = (address) => {
+  if (!address) {
+    return { addressLines: '', postcode: '' }
+  }
+
+  const lookup = address.lookup || {}
+  const manual = address.manual || {}
+  const postcode = address.postcode || ''
+  const country = address.country || ''
+  const city = address.city || ''
+
+  let lines = []
+
+  if (lookup.uprn) {
+    // The user selected an address from the lookup tool
+    const buildingAndStreet = [lookup.buildingNumberRange, lookup.street]
+      .filter(Boolean)
+      .join(' ')
+
+    lines = [
+      lookup.flatName,
+      lookup.buildingName,
+      buildingAndStreet,
+      lookup.doubleDependentLocality,
+      lookup.dependentLocality,
+      city,
+      lookup.county,
+      country
+    ]
+  } else {
+    // The user typed their address in manually
+    lines = [
+      manual.line1,
+      manual.line2,
+      manual.line3,
+      city,
+      manual.line4, // County
+      manual.line5,
+      country
+    ]
+  }
+
+  return {
+    addressLines: lines.filter(Boolean).join(', '),
+    postcode: postcode || ''
+  }
+}
+
+export {
+  searchCrnPresenter
+}

--- a/src/presenters/search/search-crn-presenter.js
+++ b/src/presenters/search/search-crn-presenter.js
@@ -3,8 +3,10 @@
  * @module searchCrnPresenter
  */
 
+import { formatAddressLines } from '../base-presenter.js'
+
 const searchCrnPresenter = (customerDetails, payload) => {
-  const { addressLines, postcode } = getFormattedAddress(customerDetails?.address)
+  const { addressLines, postcode } = formatAddressLines(customerDetails?.address)
   const resultText = customerDetails
     ? `1 result for "${payload}"`
     : `0 results for "${payload}"`
@@ -18,56 +20,6 @@ const searchCrnPresenter = (customerDetails, payload) => {
     showCustomerDetails: Boolean(customerDetails),
     showClear: true,
     crn: payload ?? ''
-  }
-}
-
-// Returns the address lines as a single string and the postcode separately.
-// The view renders postcode on its own line beneath the rest of the address.
-const getFormattedAddress = (address) => {
-  if (!address) {
-    return { addressLines: '', postcode: '' }
-  }
-
-  const lookup = address.lookup || {}
-  const manual = address.manual || {}
-  const postcode = address.postcode || ''
-  const country = address.country || ''
-  const city = address.city || ''
-
-  let lines = []
-
-  if (lookup.uprn) {
-    // The user selected an address from the lookup tool
-    const buildingAndStreet = [lookup.buildingNumberRange, lookup.street]
-      .filter(Boolean)
-      .join(' ')
-
-    lines = [
-      lookup.flatName,
-      lookup.buildingName,
-      buildingAndStreet,
-      lookup.doubleDependentLocality,
-      lookup.dependentLocality,
-      city,
-      lookup.county,
-      country
-    ]
-  } else {
-    // The user typed their address in manually
-    lines = [
-      manual.line1,
-      manual.line2,
-      manual.line3,
-      city,
-      manual.line4, // County
-      manual.line5,
-      country
-    ]
-  }
-
-  return {
-    addressLines: lines.filter(Boolean).join(', '),
-    postcode: postcode || ''
   }
 }
 

--- a/src/presenters/search/search-crn-presenter.js
+++ b/src/presenters/search/search-crn-presenter.js
@@ -5,7 +5,9 @@
 
 const searchCrnPresenter = (customerDetails, payload) => {
   const { addressLines, postcode } = getFormattedAddress(customerDetails?.address)
-  const resultText = customerDetails ? `1 result for "${payload}"` : '0 results'
+  const resultText = customerDetails
+    ? `1 result for "${payload}"`
+    : `0 results for "${payload}"`
 
   return {
     customerName: customerDetails?.info?.customerName || '',

--- a/src/presenters/search/search-sbi-presenter.js
+++ b/src/presenters/search/search-sbi-presenter.js
@@ -3,8 +3,10 @@
  * @module searchSbiPresenter
  */
 
+import { formatAddressLines } from '../base-presenter.js'
+
 const searchSbiPresenter = (businessDetails, payload) => {
-  const { addressLines, postcode } = getFormattedAddress(businessDetails?.address)
+  const { addressLines, postcode } = formatAddressLines(businessDetails?.address)
   const resultText = businessDetails
     ? `1 result for "${payload}"`
     : `0 results for "${payload}"`
@@ -20,57 +22,6 @@ const searchSbiPresenter = (businessDetails, payload) => {
     showBusinessDetails: Boolean(businessDetails),
     showClear: true,
     sbi: payload ?? ''
-  }
-}
-
-// Returns the address lines as a single string and the postcode separately.
-// The view renders postcode on its own line beneath the rest of the address.
-const getFormattedAddress = (address) => {
-  if (!address) {
-    return { addressLines: '', postcode: '' }
-  }
-
-  const lookup = address.lookup || {}
-  const manual = address.manual || {}
-  const postcode = address.postcode || ''
-  const country = address.country || ''
-  const city = address.city || ''
-
-  let lines = []
-
-  if (lookup.uprn) {
-    // The user selected an address from the lookup tool
-    const buildingAndStreet = [lookup.buildingNumberRange, lookup.street]
-      .filter(Boolean)
-      .join(' ')
-
-    lines = [
-      lookup.pafOrganisationName,
-      lookup.flatName,
-      lookup.buildingName,
-      buildingAndStreet,
-      lookup.doubleDependentLocality,
-      lookup.dependentLocality,
-      city,
-      lookup.county,
-      country
-    ]
-  } else {
-    // The user typed their address in manually
-    lines = [
-      manual.line1,
-      manual.line2,
-      manual.line3,
-      city,
-      manual.line4, // County
-      manual.line5,
-      country
-    ]
-  }
-
-  return {
-    addressLines: lines.filter(Boolean).join(', '),
-    postcode: postcode || ''
   }
 }
 

--- a/src/presenters/search/search-sbi-presenter.js
+++ b/src/presenters/search/search-sbi-presenter.js
@@ -5,7 +5,9 @@
 
 const searchSbiPresenter = (businessDetails, payload) => {
   const { addressLines, postcode } = getFormattedAddress(businessDetails?.address)
-  const resultText = businessDetails ? `1 result for "${payload}"` : '0 results'
+  const resultText = businessDetails
+    ? `1 result for "${payload}"`
+    : `0 results for "${payload}"`
 
   return {
     businessName: businessDetails?.info?.businessName || '',

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -8,6 +8,7 @@ import { cookies } from './footer/cookies-routes.js'
 import { signedOut } from './signed-out-routes.js'
 import { footerRoutes } from './footer/footer-routes.js'
 import { searchSbiRoutes } from './search/search-sbi-routes.js'
+import { searchCrnRoutes } from './search/search-crn-routes.js'
 
 export const routes = [
   health,
@@ -19,5 +20,6 @@ export const routes = [
   ...errors,
   ...staticAssetRoutes,
   ...footerRoutes,
-  ...searchSbiRoutes
+  ...searchSbiRoutes,
+  ...searchCrnRoutes
 ]

--- a/src/routes/search/search-crn-routes.js
+++ b/src/routes/search/search-crn-routes.js
@@ -1,0 +1,65 @@
+import { schemas, utils } from '@defra/fcp-sfd-frontend-engine'
+
+import { fetchCrnSearchDetailsService } from '../../services/search/fetch-crn-search-details-service.js'
+import { BAD_REQUEST } from '../../constants/status-codes.js'
+import { searchCrnPresenter } from '../../presenters/search/search-crn-presenter.js'
+
+const SEARCH_CRN_PATH = '/search-crn'
+const SEARCH_CRN_SESSION_KEY = 'searchCrn'
+const SEARCH_CRN_VIEW = 'search/search-crn'
+
+const getSearchCrn = {
+  method: 'GET',
+  path: SEARCH_CRN_PATH,
+  handler: async (request, h) => {
+    const searchState = request.yar.get(SEARCH_CRN_SESSION_KEY)
+
+    if (!searchState) {
+      return h.view(SEARCH_CRN_VIEW)
+    }
+
+    const email = request.auth.credentials?.email
+    const crnDetails = await fetchCrnSearchDetailsService(searchState.crn, email)
+    const pageData = searchCrnPresenter(crnDetails, searchState.crn)
+
+    request.yar.clear(SEARCH_CRN_SESSION_KEY)
+
+    return h.view(SEARCH_CRN_VIEW, pageData)
+  }
+}
+
+const postSearchCrn = {
+  method: 'POST',
+  path: SEARCH_CRN_PATH,
+  handler: async (request, h) => {
+    const { payload, yar } = request
+    // Trim whitespace so values like " 1234567890 " are treated as valid CRN input.
+    const crnInput = payload.crn?.trim() ?? ''
+
+    // If the user submitted an empty form, just redirect back to the search page without showing a validation error.
+    if (crnInput === '') {
+      return h.redirect(SEARCH_CRN_PATH)
+    }
+
+    const validation = schemas.customer.crn.validate({ crn: crnInput })
+
+    if (validation.error) {
+      const errors = utils.formatValidationErrors(validation.error.details || [])
+      const pageData = { ...payload, errors }
+
+      return h.view(SEARCH_CRN_VIEW, pageData).code(BAD_REQUEST).takeover()
+    }
+
+    const { crn } = validation.value
+
+    yar.set(SEARCH_CRN_SESSION_KEY, { crn })
+
+    // Save CRN in session and redirect so the GET route can fetch and render results.
+    return h.redirect(SEARCH_CRN_PATH)
+  }
+}
+
+export const searchCrnRoutes = [
+  getSearchCrn,
+  postSearchCrn
+]

--- a/src/services/search/fetch-crn-search-details-service.js
+++ b/src/services/search/fetch-crn-search-details-service.js
@@ -1,0 +1,32 @@
+/**
+ * Returns the customer details for the given CRN by querying the DAL, mapping
+ * the response and returning the mapped payload
+ *
+ * @module fetchCrnSearchDetailsService
+ */
+
+import { customerDetailsByCrn } from '../../dal/queries/customer-details-by-crn.js'
+import { getDalConnector } from '../../dal/connector.js'
+import { mapCustomerDetailsByCrn } from '../../mappers/customer-details-by-crn-mapper.js'
+
+const fetchCrnSearchDetailsService = async (crn, email) => {
+  const dalConnector = getDalConnector()
+  const dalResponse = await dalConnector.query(customerDetailsByCrn, { crn }, email)
+
+  if (dalResponse.data) {
+    const mappedResponse = mapCustomerDetailsByCrn(dalResponse.data)
+
+    return mappedResponse
+  }
+
+  const errorMessage = dalResponse?.errors?.[0]?.message
+  if (errorMessage === 'Rural payments customer not found') {
+    return null
+  }
+
+  throw new Error('Failed to retrieve customer details')
+}
+
+export {
+  fetchCrnSearchDetailsService
+}

--- a/src/views/search/search-crn.njk
+++ b/src/views/search/search-crn.njk
@@ -1,0 +1,80 @@
+{% extends 'common/layout.njk' %}
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "common/navigation/sign-out-link.njk" import appSignOutLink with context %}
+
+{% block beforeContent %}
+  {{ appSignOutLink() }}
+{% endblock %}
+
+{% block content %}
+  {% if errors %}
+    {{ govukErrorSummary({
+        titleText: "There is a problem",
+        errorList: [{
+            text: errors.crn.text,
+            href: "#crn"
+        }]
+    }) }}
+  {% endif %}
+
+<div class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post" novalidate>
+        <input type="hidden" name="crumb" value="{{ crumb }}">
+        {{ govukInput({
+            label: {
+              text: "Search by customer reference number (CRN)",
+              classes: "govuk-label--l",
+              isPageHeading: true
+            },
+            classes: "govuk-input--width-25",
+            hint: {
+              text: "Enter the full CRN"
+            },
+            id: "crn",
+            name: "crn",
+            value: crn,
+            errorMessage: errors.crn and {
+              text: errors.crn.text
+            }
+          }) }}
+
+        <div class="govuk-button-group">
+          {{ govukButton({ text: "Search", preventDoubleClick: true }) }}
+          <a class="govuk-link" href="#">Change search criteria</a>
+        </div>
+
+        {% if showClear %}
+          <p class="govuk-body">
+            <a class="govuk-link govuk-link--no-visited-state" href="/search-crn">Clear search</a>
+          </p>
+        {% endif %}
+
+        {% if showResults %}
+            <h2 class="govuk-heading-m">{{ resultText }}</h2>
+            {% if showCustomerDetails %}
+            <ol class="govuk-list internal-list__search">
+              <li class="govuk-!-padding-top-6">
+                <header class="govuk-!-padding-bottom-0">
+                  <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
+                    <a class="govuk-link govuk-link--no-visited-state" href="#">{{ customerName }}</a>
+                  </h3>
+                </header>
+                <p class="govuk-body govuk-!-margin-bottom-2">CRN: {{ crn }}</p>
+                <div>
+                  <p class="govuk-body govuk-!-margin-bottom-0">{{ customerAddress }}</p>
+                  <p class="govuk-body govuk-!-margin-bottom-2">{{ customerPostcode }}</p>
+                </div>
+              </li>
+            </ol>
+            {% endif %}
+        {% endif %}
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/test/mocks/mock-customer-details-by-crn.js
+++ b/test/mocks/mock-customer-details-by-crn.js
@@ -1,0 +1,70 @@
+/**
+ * Test-only fixture helpers for CRN customer details.
+ * Returns fresh objects so tests can safely mutate values in beforeEach blocks.
+ *
+ * @module mockCustomerDetailsByCrn
+ */
+
+const getDalData = () => ({
+  customer: {
+    crn: '1234567890',
+    info: {
+      name: {
+        first: 'Jane',
+        last: 'Smith'
+      },
+      address: {
+        buildingNumberRange: '12',
+        flatName: 'Flat 1',
+        buildingName: 'The Farm House',
+        dependentLocality: 'West Fields',
+        doubleDependentLocality: 'Rural Area',
+        street: 'Farm Lane',
+        county: 'Devon',
+        uprn: '200023456789',
+        line1: '12 Farm Lane',
+        line2: 'West Fields',
+        line3: null,
+        line4: 'Devon',
+        line5: null,
+        city: 'Exeter',
+        postalCode: 'EX1 1AA',
+        country: 'England'
+      }
+    }
+  }
+})
+
+const getMappedData = () => ({
+  info: {
+    crn: '1234567890',
+    customerName: 'Jane Smith'
+  },
+  address: {
+    lookup: {
+      buildingNumberRange: '12',
+      flatName: 'Flat 1',
+      buildingName: 'The Farm House',
+      dependentLocality: 'West Fields',
+      doubleDependentLocality: 'Rural Area',
+      street: 'Farm Lane',
+      county: 'Devon',
+      uprn: '200023456789'
+    },
+    manual: {
+      line1: '12 Farm Lane',
+      line2: 'West Fields',
+      line3: null,
+      line4: 'Devon',
+      line5: null
+    },
+    city: 'Exeter',
+    postcode: 'EX1 1AA',
+    country: 'England'
+  }
+})
+
+export {
+  getDalData,
+  getMappedData
+}

--- a/test/unit/dal/queries/customer-details-by-crn.test.js
+++ b/test/unit/dal/queries/customer-details-by-crn.test.js
@@ -1,0 +1,27 @@
+// Test framework dependencies
+import { parse } from 'graphql'
+import { describe, test, expect } from 'vitest'
+
+// Thing under test
+import { customerDetailsByCrn } from '../../../../src/dal/queries/customer-details-by-crn.js'
+
+describe('When the customerDetailsByCrn query is parsed', () => {
+  test('it is valid GraphQL syntax', () => {
+    expect(() => parse(customerDetailsByCrn)).not.toThrow()
+  })
+
+  test('it contains the Query operation and the correct variable', () => {
+    // Parsing the GQL query returns an Abstract Syntax Tree (ast)
+    // this converts the string into a structural representation of the query.
+    // This allows it to be inspected and validated.
+
+    const ast = parse(customerDetailsByCrn)
+    const operation = ast.definitions[0]
+    expect(operation.name.value).toBe('Customer')
+
+    const variable = operation.variableDefinitions[0]
+    expect(variable.variable.name.value).toBe('crn')
+    expect(variable.type.kind).toBe('NonNullType')
+    expect(variable.type.type.name.value).toBe('ID')
+  })
+})

--- a/test/unit/mappers/customer-details-by-crn-mapper.test.js
+++ b/test/unit/mappers/customer-details-by-crn-mapper.test.js
@@ -92,6 +92,18 @@ describe('customer details by CRN mapper', () => {
     })
   })
 
+  describe('when the name object is null', () => {
+    beforeEach(() => {
+      rawData.customer.info.name = null
+    })
+
+    test('it maps name fields to undefined without crashing', () => {
+      const result = mapCustomerDetailsByCrn(rawData)
+
+      expect(result.info.customerName).toEqual('undefined undefined')
+    })
+  })
+
   describe('when the address object is null', () => {
     beforeEach(() => {
       rawData.customer.info.address = null

--- a/test/unit/mappers/customer-details-by-crn-mapper.test.js
+++ b/test/unit/mappers/customer-details-by-crn-mapper.test.js
@@ -1,0 +1,125 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach } from 'vitest'
+
+// Thing under test
+import { mapCustomerDetailsByCrn } from '../../../src/mappers/customer-details-by-crn-mapper.js'
+
+// Test helpers
+import { getDalData, getMappedData } from '../../mocks/mock-customer-details-by-crn.js'
+
+describe('customer details by CRN mapper', () => {
+  let rawData
+
+  beforeEach(() => {
+    rawData = getDalData()
+  })
+
+  test('it maps all fields correctly', () => {
+    const result = mapCustomerDetailsByCrn(rawData)
+
+    expect(result).toEqual(getMappedData())
+  })
+
+  test('it concatenates first and last name into customerName', () => {
+    rawData.customer.info.name.first = 'John'
+    rawData.customer.info.name.last = 'Doe'
+
+    const result = mapCustomerDetailsByCrn(rawData)
+
+    expect(result.info.customerName).toEqual('John Doe')
+  })
+
+  describe('when the address has no lookup fields', () => {
+    beforeEach(() => {
+      rawData.customer.info.address.buildingNumberRange = null
+      rawData.customer.info.address.flatName = null
+      rawData.customer.info.address.buildingName = null
+      rawData.customer.info.address.dependentLocality = null
+      rawData.customer.info.address.doubleDependentLocality = null
+      rawData.customer.info.address.street = null
+      rawData.customer.info.address.county = null
+      rawData.customer.info.address.uprn = null
+    })
+
+    test('it maps all lookup fields as null', () => {
+      const result = mapCustomerDetailsByCrn(rawData)
+
+      expect(result.address.lookup).toEqual({
+        buildingNumberRange: null,
+        flatName: null,
+        buildingName: null,
+        dependentLocality: null,
+        doubleDependentLocality: null,
+        street: null,
+        county: null,
+        uprn: null
+      })
+    })
+  })
+
+  describe('when the address uses manual entry only', () => {
+    beforeEach(() => {
+      rawData.customer.info.address.uprn = null
+      rawData.customer.info.address.line1 = '12 Farm Lane'
+      rawData.customer.info.address.line2 = null
+      rawData.customer.info.address.line3 = null
+      rawData.customer.info.address.line4 = null
+      rawData.customer.info.address.line5 = null
+    })
+
+    test('it maps manual address fields correctly', () => {
+      const result = mapCustomerDetailsByCrn(rawData)
+
+      expect(result.address.manual).toEqual({
+        line1: '12 Farm Lane',
+        line2: null,
+        line3: null,
+        line4: null,
+        line5: null
+      })
+    })
+  })
+
+  describe('when the postalCode field is used for postcode', () => {
+    beforeEach(() => {
+      rawData.customer.info.address.postalCode = 'EX1 2AB'
+    })
+
+    test('it maps postalCode to postcode', () => {
+      const result = mapCustomerDetailsByCrn(rawData)
+
+      expect(result.address.postcode).toEqual('EX1 2AB')
+    })
+  })
+
+  describe('when the address object is null', () => {
+    beforeEach(() => {
+      rawData.customer.info.address = null
+    })
+
+    test('it maps all address fields to null without crashing', () => {
+      const result = mapCustomerDetailsByCrn(rawData)
+
+      expect(result.address.lookup).toEqual({
+        buildingNumberRange: undefined,
+        flatName: undefined,
+        buildingName: undefined,
+        dependentLocality: undefined,
+        doubleDependentLocality: undefined,
+        street: undefined,
+        county: undefined,
+        uprn: undefined
+      })
+      expect(result.address.manual).toEqual({
+        line1: undefined,
+        line2: undefined,
+        line3: undefined,
+        line4: undefined,
+        line5: undefined
+      })
+      expect(result.address.city).toEqual(undefined)
+      expect(result.address.postcode).toEqual(undefined)
+      expect(result.address.country).toEqual(undefined)
+    })
+  })
+})

--- a/test/unit/presenters/base-presenter.test.js
+++ b/test/unit/presenters/base-presenter.test.js
@@ -1,0 +1,146 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach } from 'vitest'
+
+// Thing under test
+import { formatAddressLines } from '../../../src/presenters/base-presenter.js'
+
+describe('basePresenter', () => {
+  describe('#formatAddressLines', () => {
+    let address
+
+    describe('when the address is a lookup address with pafOrganisationName', () => {
+      beforeEach(() => {
+        address = {
+          lookup: {
+            pafOrganisationName: 'Herberts Lawn Mowing Ltd',
+            flatName: 'Flat 2',
+            buildingName: 'The Lawn Building',
+            buildingNumberRange: '14',
+            street: 'Chip Lane',
+            doubleDependentLocality: 'Chip Lane Area',
+            dependentLocality: 'Taunton Borough',
+            county: 'Somerset',
+            uprn: '100012345678'
+          },
+          manual: {},
+          city: 'Taunton',
+          postcode: 'TA1 1AA',
+          country: 'England'
+        }
+      })
+
+      test('it should return the formatted address lines and postcode', () => {
+        const result = formatAddressLines(address)
+
+        expect(result).toEqual({
+          addressLines: 'Herberts Lawn Mowing Ltd, Flat 2, The Lawn Building, 14 Chip Lane, Chip Lane Area, Taunton Borough, Taunton, Somerset, England',
+          postcode: 'TA1 1AA'
+        })
+      })
+    })
+
+    describe('when the address is a lookup address without pafOrganisationName', () => {
+      beforeEach(() => {
+        address = {
+          lookup: {
+            flatName: 'Flat 1',
+            buildingName: 'The Farm House',
+            buildingNumberRange: '12',
+            street: 'Farm Lane',
+            doubleDependentLocality: 'Rural Area',
+            dependentLocality: 'West Fields',
+            county: 'Devon',
+            uprn: '200023456789'
+          },
+          manual: {},
+          city: 'Exeter',
+          postcode: 'EX1 1AA',
+          country: 'England'
+        }
+      })
+
+      test('it should return the formatted address lines and postcode without an organisation name', () => {
+        const result = formatAddressLines(address)
+
+        expect(result).toEqual({
+          addressLines: 'Flat 1, The Farm House, 12 Farm Lane, Rural Area, West Fields, Exeter, Devon, England',
+          postcode: 'EX1 1AA'
+        })
+      })
+    })
+
+    describe('when the address is manually entered', () => {
+      beforeEach(() => {
+        address = {
+          lookup: { uprn: null },
+          manual: {
+            line1: '12 Farm Lane',
+            line2: 'West Fields',
+            line3: null,
+            line4: 'Devon',
+            line5: null
+          },
+          city: 'Exeter',
+          postcode: 'EX1 1AA',
+          country: 'England'
+        }
+      })
+
+      test('it should return the formatted address lines from manual fields', () => {
+        const result = formatAddressLines(address)
+
+        expect(result).toEqual({
+          addressLines: '12 Farm Lane, West Fields, Exeter, Devon, England',
+          postcode: 'EX1 1AA'
+        })
+      })
+    })
+
+    describe('when the address is null', () => {
+      test('it should return empty strings for both addressLines and postcode', () => {
+        const result = formatAddressLines(null)
+
+        expect(result).toEqual({
+          addressLines: '',
+          postcode: ''
+        })
+      })
+    })
+
+    describe('when the address is undefined', () => {
+      test('it should return empty strings for both addressLines and postcode', () => {
+        const result = formatAddressLines(undefined)
+
+        expect(result).toEqual({
+          addressLines: '',
+          postcode: ''
+        })
+      })
+    })
+
+    describe('when some optional lookup fields are missing', () => {
+      beforeEach(() => {
+        address = {
+          lookup: {
+            buildingNumberRange: '10',
+            street: 'Main Street',
+            uprn: '300000000001'
+          },
+          manual: {},
+          city: 'Bristol',
+          postcode: 'BS1 1AA',
+          country: 'England'
+        }
+      })
+
+      test('it should omit the missing fields from the address lines', () => {
+        const result = formatAddressLines(address)
+
+        expect(result).toEqual({
+          addressLines: '10 Main Street, Bristol, England',
+          postcode: 'BS1 1AA'
+        })
+      })
+    })
+  })
+})

--- a/test/unit/presenters/search/search-crn-presenter.test.js
+++ b/test/unit/presenters/search/search-crn-presenter.test.js
@@ -111,7 +111,7 @@ describe('searchCrnPresenter', () => {
       test('it should return 0 results', () => {
         const result = searchCrnPresenter(data, payload)
 
-        expect(result.resultText).toEqual('0 results')
+        expect(result.resultText).toEqual('0 results for "1234567890"')
       })
     })
   })

--- a/test/unit/presenters/search/search-crn-presenter.test.js
+++ b/test/unit/presenters/search/search-crn-presenter.test.js
@@ -1,0 +1,132 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach } from 'vitest'
+
+// Test helpers
+import { getMappedData } from '../../../mocks/mock-customer-details-by-crn.js'
+
+// Thing under test
+import { searchCrnPresenter } from '../../../../src/presenters/search/search-crn-presenter.js'
+
+describe('searchCrnPresenter', () => {
+  let data
+  let payload
+
+  beforeEach(() => {
+    data = getMappedData()
+
+    payload = '1234567890'
+  })
+
+  describe('when provided with customer details and payload', () => {
+    test('it correctly presents the data', () => {
+      const result = searchCrnPresenter(data, payload)
+
+      expect(result).toEqual({
+        customerName: 'Jane Smith',
+        customerAddress: 'Flat 1, The Farm House, 12 Farm Lane, Rural Area, West Fields, Exeter, Devon, England',
+        customerPostcode: 'EX1 1AA',
+        resultText: '1 result for "1234567890"',
+        showResults: true,
+        showCustomerDetails: true,
+        showClear: true,
+        crn: '1234567890'
+      })
+    })
+  })
+
+  describe('the "customerName" property', () => {
+    describe('when the customerName property is missing', () => {
+      beforeEach(() => {
+        delete data.info.customerName
+      })
+
+      test('it should return customerName as an empty string', () => {
+        const result = searchCrnPresenter(data, payload)
+
+        expect(result.customerName).toEqual('')
+      })
+    })
+  })
+
+  describe('the "customerAddress" property', () => {
+    describe('when the address is manually entered', () => {
+      beforeEach(() => {
+        data.address.lookup.uprn = null
+      })
+
+      test('it should build the address from manual fields', () => {
+        const result = searchCrnPresenter(data, payload)
+
+        expect(result.customerAddress).toEqual('12 Farm Lane, West Fields, Exeter, Devon, England')
+      })
+    })
+
+    describe('when the address is missing', () => {
+      beforeEach(() => {
+        delete data.address
+      })
+
+      test('it should return customerAddress as an empty string', () => {
+        const result = searchCrnPresenter(data, payload)
+
+        expect(result.customerAddress).toEqual('')
+      })
+    })
+  })
+
+  describe('the "customerPostcode" property', () => {
+    describe('when the address is missing', () => {
+      beforeEach(() => {
+        delete data.address
+      })
+
+      test('it should return customerPostcode as an empty string', () => {
+        const result = searchCrnPresenter(data, payload)
+
+        expect(result.customerPostcode).toEqual('')
+      })
+    })
+  })
+
+  describe('the "showCustomerDetails" property', () => {
+    describe('when customer details are missing', () => {
+      beforeEach(() => {
+        data = null
+      })
+
+      test('it should return showCustomerDetails as false', () => {
+        const result = searchCrnPresenter(data, payload)
+
+        expect(result.showCustomerDetails).toEqual(false)
+      })
+    })
+  })
+
+  describe('the "resultText" property', () => {
+    describe('when customer details are missing', () => {
+      beforeEach(() => {
+        data = null
+      })
+
+      test('it should return 0 results', () => {
+        const result = searchCrnPresenter(data, payload)
+
+        expect(result.resultText).toEqual('0 results')
+      })
+    })
+  })
+
+  describe('the "crn" property', () => {
+    describe('when payload is missing', () => {
+      beforeEach(() => {
+        payload = null
+      })
+
+      test('it should return crn as an empty string', () => {
+        const result = searchCrnPresenter(data, payload)
+
+        expect(result.crn).toEqual('')
+      })
+    })
+  })
+})

--- a/test/unit/presenters/search/search-sbi-presenter.test.js
+++ b/test/unit/presenters/search/search-sbi-presenter.test.js
@@ -141,7 +141,7 @@ describe('searchSbiPresenter', () => {
       test('it should return 0 results', () => {
         const result = searchSbiPresenter(data, payload)
 
-        expect(result.resultText).toEqual('0 results')
+        expect(result.resultText).toEqual('0 results for "106705779"')
       })
     })
   })

--- a/test/unit/routes/search/search-crn-routes.test.js
+++ b/test/unit/routes/search/search-crn-routes.test.js
@@ -1,0 +1,197 @@
+// Test framework dependencies
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+// Things we need to mock
+import { fetchCrnSearchDetailsService } from '../../../../src/services/search/fetch-crn-search-details-service.js'
+import { searchCrnPresenter } from '../../../../src/presenters/search/search-crn-presenter.js'
+
+// Test helpers
+import { BAD_REQUEST } from '../../../../src/constants/status-codes.js'
+
+// Thing under test
+import { searchCrnRoutes } from '../../../../src/routes/search/search-crn-routes.js'
+const [getSearchCrn, postSearchCrn] = searchCrnRoutes
+
+const { mockValidate, mockFormatValidationErrors } = vi.hoisted(() => ({
+  mockValidate: vi.fn(),
+  mockFormatValidationErrors: vi.fn()
+}))
+
+vi.mock('@defra/fcp-sfd-frontend-engine', () => ({
+  schemas: {
+    customer: {
+      crn: {
+        validate: mockValidate
+      }
+    }
+  },
+  utils: {
+    formatValidationErrors: mockFormatValidationErrors
+  }
+}))
+
+// Mocks
+vi.mock('../../../../src/services/search/fetch-crn-search-details-service.js', () => ({
+  fetchCrnSearchDetailsService: vi.fn()
+}))
+
+vi.mock('../../../../src/presenters/search/search-crn-presenter.js', () => ({
+  searchCrnPresenter: vi.fn()
+}))
+
+describe('search crn routes', () => {
+  let request
+  let h
+  let responseStub
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    responseStub = {
+      code: vi.fn().mockReturnThis(),
+      takeover: vi.fn().mockReturnThis()
+    }
+
+    request = {
+      yar: {
+        get: vi.fn(),
+        set: vi.fn(),
+        clear: vi.fn()
+      },
+      auth: {
+        credentials: {
+          email: 'test@example.com'
+        }
+      },
+      payload: {
+        crn: '1234567890'
+      }
+    }
+
+    h = {
+      view: vi.fn(() => responseStub),
+      redirect: vi.fn()
+    }
+  })
+
+  describe('GET /search-crn', () => {
+    test('should have the correct method and path configured', () => {
+      expect(getSearchCrn.method).toBe('GET')
+      expect(getSearchCrn.path).toBe('/search-crn')
+    })
+
+    describe('when no CRN is in session', () => {
+      beforeEach(() => {
+        request.yar.get.mockReturnValue(undefined)
+      })
+
+      test('it renders the search page with no page data', async () => {
+        await getSearchCrn.handler(request, h)
+
+        expect(request.yar.get).toHaveBeenCalledWith('searchCrn')
+        expect(h.view).toHaveBeenCalledWith('search/search-crn')
+        expect(fetchCrnSearchDetailsService).not.toHaveBeenCalled()
+        expect(searchCrnPresenter).not.toHaveBeenCalled()
+        expect(request.yar.clear).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when a CRN is in session', () => {
+      const searchState = { crn: '1234567890' }
+      const details = { info: { customerName: 'Jane Smith' } }
+      const pageData = { resultText: '1 result for "1234567890"' }
+
+      beforeEach(() => {
+        request.yar.get.mockReturnValue(searchState)
+        fetchCrnSearchDetailsService.mockResolvedValue(details)
+        searchCrnPresenter.mockReturnValue(pageData)
+      })
+
+      test('it fetches details, presents them and clears session state', async () => {
+        await getSearchCrn.handler(request, h)
+
+        expect(request.yar.get).toHaveBeenCalledWith('searchCrn')
+        expect(fetchCrnSearchDetailsService).toHaveBeenCalledWith('1234567890', 'test@example.com')
+        expect(searchCrnPresenter).toHaveBeenCalledWith(details, '1234567890')
+        expect(request.yar.clear).toHaveBeenCalledWith('searchCrn')
+        expect(h.view).toHaveBeenCalledWith('search/search-crn', pageData)
+      })
+    })
+  })
+
+  describe('POST /search-crn', () => {
+    test('should have the correct method and path configured', () => {
+      expect(postSearchCrn.method).toBe('POST')
+      expect(postSearchCrn.path).toBe('/search-crn')
+    })
+
+    describe('when the submitted CRN is empty after trimming', () => {
+      beforeEach(() => {
+        request.payload = { crn: '   ' }
+      })
+
+      test('it redirects back to /search-crn without validating', async () => {
+        await postSearchCrn.handler(request, h)
+
+        expect(h.redirect).toHaveBeenCalledWith('/search-crn')
+        expect(mockValidate).not.toHaveBeenCalled()
+        expect(request.yar.set).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when validation fails', () => {
+      const validationError = {
+        details: [
+          {
+            message: 'Enter the full CRN',
+            path: ['crn'],
+            type: 'string.pattern.base'
+          }
+        ]
+      }
+
+      beforeEach(() => {
+        request.payload = { crn: 'abc123' }
+        mockValidate.mockReturnValue({ error: validationError })
+        mockFormatValidationErrors.mockReturnValue({
+          crn: {
+            text: 'Enter the full CRN'
+          }
+        })
+      })
+
+      test('it renders the view with formatted errors and bad request status', async () => {
+        await postSearchCrn.handler(request, h)
+
+        expect(mockValidate).toHaveBeenCalledWith({ crn: 'abc123' })
+        expect(mockFormatValidationErrors).toHaveBeenCalledWith(validationError.details)
+        expect(h.view).toHaveBeenCalledWith('search/search-crn', {
+          crn: 'abc123',
+          errors: {
+            crn: {
+              text: 'Enter the full CRN'
+            }
+          }
+        })
+        expect(responseStub.code).toHaveBeenCalledWith(BAD_REQUEST)
+        expect(responseStub.takeover).toHaveBeenCalled()
+        expect(request.yar.set).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when validation succeeds', () => {
+      beforeEach(() => {
+        request.payload = { crn: ' 1234567890 ' }
+        mockValidate.mockReturnValue({ value: { crn: '1234567890' } })
+      })
+
+      test('it trims input, stores CRN in session and redirects', async () => {
+        await postSearchCrn.handler(request, h)
+
+        expect(mockValidate).toHaveBeenCalledWith({ crn: '1234567890' })
+        expect(request.yar.set).toHaveBeenCalledWith('searchCrn', { crn: '1234567890' })
+        expect(h.redirect).toHaveBeenCalledWith('/search-crn')
+      })
+    })
+  })
+})

--- a/test/unit/services/search/fetch-crn-search-details-service.test.js
+++ b/test/unit/services/search/fetch-crn-search-details-service.test.js
@@ -1,0 +1,130 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+// Things we need to mock
+import { customerDetailsByCrn } from '../../../../src/dal/queries/customer-details-by-crn.js'
+
+// Test helpers
+import { getDalData, getMappedData } from '../../../mocks/mock-customer-details-by-crn.js'
+
+// Mock dependencies
+const mockMapCustomerDetailsByCrn = vi.fn()
+const mockDalConnector = { query: vi.fn() }
+
+// Mock imports
+vi.mock('../../../../src/dal/connector.js', () => ({
+  getDalConnector: vi.fn(() => mockDalConnector)
+}))
+
+vi.mock('../../../../src/mappers/customer-details-by-crn-mapper.js', () => ({
+  mapCustomerDetailsByCrn: mockMapCustomerDetailsByCrn
+}))
+
+// Thing under test
+const { fetchCrnSearchDetailsService } = await import('../../../../src/services/search/fetch-crn-search-details-service.js')
+
+describe('fetchCrnSearchDetailsService', () => {
+  let crn
+  let email
+  let dalData
+  let mappedData
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    crn = '1234567890'
+    email = 'test.farmer@test.farm.com'
+
+    dalData = getDalData()
+    mappedData = getMappedData()
+  })
+
+  describe('when DAL returns data', () => {
+    beforeEach(() => {
+      mockDalConnector.query.mockResolvedValue({ data: dalData })
+      mockMapCustomerDetailsByCrn.mockReturnValue(mappedData)
+    })
+
+    test('should call DAL connector with customerDetailsByCrn and crn', async () => {
+      await fetchCrnSearchDetailsService(crn, email)
+
+      expect(mockDalConnector.query).toHaveBeenCalledWith(
+        customerDetailsByCrn,
+        { crn },
+        email
+      )
+    })
+
+    test('should return mapped data', async () => {
+      const result = await fetchCrnSearchDetailsService(crn, email)
+
+      expect(mockDalConnector.query).toHaveBeenCalled()
+      expect(mockMapCustomerDetailsByCrn).toHaveBeenCalledWith(dalData)
+      expect(result).toEqual(mappedData)
+    })
+  })
+
+  describe('when the DAL says customer is not found', () => {
+    beforeEach(() => {
+      mockDalConnector.query.mockResolvedValue({
+        data: null,
+        errors: [{ message: 'Rural payments customer not found' }],
+        statusCode: 200
+      })
+    })
+
+    test('should return null', async () => {
+      const result = await fetchCrnSearchDetailsService(crn, email)
+
+      expect(result).toEqual(null)
+      expect(mockMapCustomerDetailsByCrn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the DAL returns another error', () => {
+    beforeEach(() => {
+      mockDalConnector.query.mockResolvedValue({
+        data: null,
+        errors: [{ message: 'error response from dal' }],
+        statusCode: 500
+      })
+    })
+
+    test('should throw a generic error', async () => {
+      await expect(fetchCrnSearchDetailsService(crn, email)).rejects.toThrowError('Failed to retrieve customer details')
+
+      expect(mockMapCustomerDetailsByCrn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the DAL response has no errors property', () => {
+    beforeEach(() => {
+      mockDalConnector.query.mockResolvedValue({
+        data: null,
+        statusCode: 500
+      })
+    })
+
+    test('should throw a generic error without crashing on undefined errors', async () => {
+      await expect(fetchCrnSearchDetailsService(crn, email)).rejects.toThrowError('Failed to retrieve customer details')
+
+      expect(mockMapCustomerDetailsByCrn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the DAL response has an empty errors array', () => {
+    beforeEach(() => {
+      mockDalConnector.query.mockResolvedValue({
+        data: null,
+        errors: [],
+        statusCode: 500
+      })
+    })
+
+    test('should throw a generic error without crashing on empty array', async () => {
+      await expect(fetchCrnSearchDetailsService(crn, email)).rejects.toThrowError('Failed to retrieve customer details')
+
+      expect(mockMapCustomerDetailsByCrn).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FLS2-34

## Add CRN search feature

Adds a new `/search-crn` page allowing internal users to search for a customer by their Customer Reference Number (CRN) and view their details.

### Changes

**Routes**
- `src/routes/search/search-crn-routes.js` — GET/POST handlers for `/search-crn`. The POST validates the CRN input using the `schemas.customer.crn` schema from `@defra/fcp-sfd-frontend-engine`, stores a valid CRN in session, then redirects to GET. The GET fetches customer details from the DAL and passes them to the presenter.

**DAL**
- `src/dal/queries/customer-details-by-crn.js` — GraphQL query fetching customer name and full address by CRN.

**Service**
- `src/services/search/fetch-crn-search-details-service.js` — Calls the DAL connector with the CRN query, maps the response, and handles the "customer not found" case gracefully (returns `null`).

**Mapper**
- `src/mappers/customer-details-by-crn-mapper.js` — Maps raw DAL customer data into `info` (CRN, full name) and `address` (lookup, manual, city, postcode, country) shape.

**Presenter**
- `src/presenters/search/search-crn-presenter.js` — Formats customer details for the view, including result count text, formatted address lines, and display flags.

**View**
- `src/views/search/search-crn.njk` — Nunjucks template for the search page and results.

### Tests

Unit tests added for the service, DAL query, mapper, presenter, and routes.