### PR TITLE
FLS2-43: Add Search Criteria Selection Page

### DIFF
--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -9,6 +9,7 @@ import { signedOut } from './signed-out-routes.js'
 import { footerRoutes } from './footer/footer-routes.js'
 import { searchSbiRoutes } from './search/search-sbi-routes.js'
 import { searchCrnRoutes } from './search/search-crn-routes.js'
+import { changeSearchCriteriaRoutes } from './search/change-search-criteria-routes.js'
 
 export const routes = [
   health,
@@ -21,5 +22,6 @@ export const routes = [
   ...staticAssetRoutes,
   ...footerRoutes,
   ...searchSbiRoutes,
-  ...searchCrnRoutes
+  ...searchCrnRoutes,
+  ...changeSearchCriteriaRoutes
 ]

--- a/src/routes/search/change-search-criteria-routes.js
+++ b/src/routes/search/change-search-criteria-routes.js
@@ -28,6 +28,7 @@ const postChangeSearchCriteria = {
       options: { abortEarly: false },
       failAction: async (_request, h, err) => {
         const errors = utils.formatValidationErrors(err.details || [])
+
         return h.view(CHANGE_SEARCH_CRITERIA_VIEW, { errors }).code(BAD_REQUEST).takeover()
       }
     },

--- a/src/routes/search/change-search-criteria-routes.js
+++ b/src/routes/search/change-search-criteria-routes.js
@@ -4,7 +4,6 @@ import { searchCriteriaSchema } from '../../schemas/search/search-criteria-schem
 import { BAD_REQUEST } from '../../constants/status-codes.js'
 
 const CHANGE_SEARCH_CRITERIA_PATH = '/change-search-criteria'
-const CHANGE_SEARCH_CRITERIA_SESSION_KEY = 'changeSearchCriteria'
 const CHANGE_SEARCH_CRITERIA_VIEW = 'search/change-search-criteria'
 
 const SEARCH_PATHS = {
@@ -16,17 +15,7 @@ const getChangeSearchCriteria = {
   method: 'GET',
   path: CHANGE_SEARCH_CRITERIA_PATH,
   handler: async (request, h) => {
-    const searchState = request.yar.get(CHANGE_SEARCH_CRITERIA_SESSION_KEY)
-
-    if (!searchState) {
-      return h.view(CHANGE_SEARCH_CRITERIA_VIEW)
-    }
-
-    const { searchCriteria } = searchState
-
-    request.yar.clear(CHANGE_SEARCH_CRITERIA_SESSION_KEY)
-
-    return h.redirect(SEARCH_PATHS[searchCriteria])
+    return h.view(CHANGE_SEARCH_CRITERIA_VIEW)
   }
 }
 
@@ -45,9 +34,7 @@ const postChangeSearchCriteria = {
     handler: async (request, h) => {
       const { searchCriteria } = request.payload
 
-      request.yar.set(CHANGE_SEARCH_CRITERIA_SESSION_KEY, { searchCriteria })
-
-      return h.redirect(CHANGE_SEARCH_CRITERIA_PATH)
+      return h.redirect(SEARCH_PATHS[searchCriteria])
     }
   }
 }

--- a/src/routes/search/change-search-criteria-routes.js
+++ b/src/routes/search/change-search-criteria-routes.js
@@ -1,0 +1,50 @@
+import { BAD_REQUEST } from '../../constants/status-codes.js'
+
+const CHANGE_SEARCH_CRITERIA_PATH = '/change-search-criteria'
+const CHANGE_SEARCH_CRITERIA_SESSION_KEY = 'changeSearchCriteria'
+const CHANGE_SEARCH_CRITERIA_VIEW = 'search/change-search-criteria'
+
+const SEARCH_PATHS = {
+  sbi: '/search-sbi',
+  crn: '/search-crn'
+}
+
+const getChangeSearchCriteria = {
+  method: 'GET',
+  path: CHANGE_SEARCH_CRITERIA_PATH,
+  handler: async (request, h) => {
+    const searchState = request.yar.get(CHANGE_SEARCH_CRITERIA_SESSION_KEY)
+
+    if (!searchState) {
+      return h.view(CHANGE_SEARCH_CRITERIA_VIEW)
+    }
+
+    const { searchCriteria } = searchState
+
+    request.yar.clear(CHANGE_SEARCH_CRITERIA_SESSION_KEY)
+
+    return h.redirect(SEARCH_PATHS[searchCriteria])
+  }
+}
+
+const postChangeSearchCriteria = {
+  method: 'POST',
+  path: CHANGE_SEARCH_CRITERIA_PATH,
+  handler: async (request, h) => {
+    const { searchCriteria } = request.payload
+
+    if (!searchCriteria) {
+      const errors = { searchCriteria: { text: 'Select what you want to search by' } }
+      return h.view(CHANGE_SEARCH_CRITERIA_VIEW, { errors }).code(BAD_REQUEST).takeover()
+    }
+
+    request.yar.set(CHANGE_SEARCH_CRITERIA_SESSION_KEY, { searchCriteria })
+
+    return h.redirect(CHANGE_SEARCH_CRITERIA_PATH)
+  }
+}
+
+export const changeSearchCriteriaRoutes = [
+  getChangeSearchCriteria,
+  postChangeSearchCriteria
+]

--- a/src/routes/search/change-search-criteria-routes.js
+++ b/src/routes/search/change-search-criteria-routes.js
@@ -1,3 +1,6 @@
+import { utils } from '@defra/fcp-sfd-frontend-engine'
+
+import { searchCriteriaSchema } from '../../schemas/search/search-criteria-schema.js'
 import { BAD_REQUEST } from '../../constants/status-codes.js'
 
 const CHANGE_SEARCH_CRITERIA_PATH = '/change-search-criteria'
@@ -30,17 +33,22 @@ const getChangeSearchCriteria = {
 const postChangeSearchCriteria = {
   method: 'POST',
   path: CHANGE_SEARCH_CRITERIA_PATH,
-  handler: async (request, h) => {
-    const { searchCriteria } = request.payload
+  options: {
+    validate: {
+      payload: searchCriteriaSchema,
+      options: { abortEarly: false },
+      failAction: async (request, h, err) => {
+        const errors = utils.formatValidationErrors(err.details || [])
+        return h.view(CHANGE_SEARCH_CRITERIA_VIEW, { errors }).code(BAD_REQUEST).takeover()
+      }
+    },
+    handler: async (request, h) => {
+      const { searchCriteria } = request.payload
 
-    if (!searchCriteria) {
-      const errors = { searchCriteria: { text: 'Select what you want to search by' } }
-      return h.view(CHANGE_SEARCH_CRITERIA_VIEW, { errors }).code(BAD_REQUEST).takeover()
+      request.yar.set(CHANGE_SEARCH_CRITERIA_SESSION_KEY, { searchCriteria })
+
+      return h.redirect(CHANGE_SEARCH_CRITERIA_PATH)
     }
-
-    request.yar.set(CHANGE_SEARCH_CRITERIA_SESSION_KEY, { searchCriteria })
-
-    return h.redirect(CHANGE_SEARCH_CRITERIA_PATH)
   }
 }
 

--- a/src/routes/search/change-search-criteria-routes.js
+++ b/src/routes/search/change-search-criteria-routes.js
@@ -14,7 +14,7 @@ const SEARCH_PATHS = {
 const getChangeSearchCriteria = {
   method: 'GET',
   path: CHANGE_SEARCH_CRITERIA_PATH,
-  handler: async (request, h) => {
+  handler: async (_request, h) => {
     return h.view(CHANGE_SEARCH_CRITERIA_VIEW)
   }
 }
@@ -26,7 +26,7 @@ const postChangeSearchCriteria = {
     validate: {
       payload: searchCriteriaSchema,
       options: { abortEarly: false },
-      failAction: async (request, h, err) => {
+      failAction: async (_request, h, err) => {
         const errors = utils.formatValidationErrors(err.details || [])
         return h.view(CHANGE_SEARCH_CRITERIA_VIEW, { errors }).code(BAD_REQUEST).takeover()
       }

--- a/src/schemas/search/search-criteria-schema.js
+++ b/src/schemas/search/search-criteria-schema.js
@@ -1,0 +1,15 @@
+import Joi from 'joi'
+
+const VALID_VALUES = ['sbi', 'crn']
+const ERROR_MESSAGE = 'Select what you want to search by'
+
+export const searchCriteriaSchema = Joi.object({
+  searchCriteria: Joi.string()
+    .required()
+    .valid(...VALID_VALUES)
+    .messages({
+      'any.required': ERROR_MESSAGE,
+      'any.only': ERROR_MESSAGE,
+      'string.empty': ERROR_MESSAGE
+    })
+})

--- a/src/views/search/change-search-criteria.njk
+++ b/src/views/search/change-search-criteria.njk
@@ -1,0 +1,62 @@
+{% extends 'common/layout.njk' %}
+
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "common/navigation/sign-out-link.njk" import appSignOutLink with context %}
+
+{% set pageTitle = "What do you want to search by?" %}
+{% set metaDescription = "Select the criteria you want to search by to find a customer or business." %}
+
+{% block beforeContent %}
+  {{ appSignOutLink() }}
+{% endblock %}
+
+{% block content %}
+  {% if errors %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: [{
+        text: errors.searchCriteria.text,
+        href: "#searchCriteria"
+      }]
+    }) }}
+  {% endif %}
+
+  <div class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <form method="post" novalidate>
+          <input type="hidden" name="crumb" value="{{ crumb }}">
+
+          {{ govukRadios({
+            name: "searchCriteria",
+            idPrefix: "searchCriteria",
+            fieldset: {
+              legend: {
+                text: "What do you want to search by?",
+                classes: "govuk-fieldset__legend--l",
+                isPageHeading: true
+              }
+            },
+            errorMessage: errors.searchCriteria and {
+              text: errors.searchCriteria.text
+            },
+            items: [
+              {
+                value: "sbi",
+                text: "Single business identifier (SBI)"
+              },
+              {
+                value: "crn",
+                text: "Customer reference number (CRN)"
+              }
+            ]
+          }) }}
+
+          {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
+        </form>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/src/views/search/search-crn.njk
+++ b/src/views/search/search-crn.njk
@@ -45,7 +45,7 @@
 
         <div class="govuk-button-group">
           {{ govukButton({ text: "Search", preventDoubleClick: true }) }}
-          <a class="govuk-link" href="#">Change search criteria</a>
+          <a class="govuk-link" href="/change-search-criteria">Change search criteria</a>
         </div>
 
         {% if showClear %}

--- a/src/views/search/search-sbi.njk
+++ b/src/views/search/search-sbi.njk
@@ -45,7 +45,7 @@
 
         <div class="govuk-button-group">
           {{ govukButton({ text: "Search", preventDoubleClick: true }) }}
-          <a class="govuk-link" href="#">Change search criteria</a>
+          <a class="govuk-link" href="/change-search-criteria">Change search criteria</a>
         </div>
 
         {% if showClear %}

--- a/test/unit/routes/search/change-search-criteria-routes.test.js
+++ b/test/unit/routes/search/change-search-criteria-routes.test.js
@@ -94,13 +94,23 @@ describe('change search criteria routes', () => {
       expect(postChangeSearchCriteria.path).toBe('/change-search-criteria')
     })
 
-    describe('when no option is selected', () => {
+    describe('when the validation fails', () => {
+      let err
+
       beforeEach(() => {
-        request.payload = {}
+        err = {
+          details: [
+            {
+              message: 'Select what you want to search by',
+              path: ['searchCriteria'],
+              type: 'any.required'
+            }
+          ]
+        }
       })
 
       test('it renders the view with a validation error and bad request status', async () => {
-        await postChangeSearchCriteria.handler(request, h)
+        await postChangeSearchCriteria.options.validate.failAction(request, h, err)
 
         expect(h.view).toHaveBeenCalledWith('search/change-search-criteria', {
           errors: {
@@ -111,8 +121,16 @@ describe('change search criteria routes', () => {
         })
         expect(responseStub.code).toHaveBeenCalledWith(BAD_REQUEST)
         expect(responseStub.takeover).toHaveBeenCalled()
-        expect(request.yar.set).not.toHaveBeenCalled()
-        expect(h.redirect).not.toHaveBeenCalled()
+      })
+
+      test('it should handle undefined errors', async () => {
+        await postChangeSearchCriteria.options.validate.failAction(request, h, [])
+
+        expect(h.view).toHaveBeenCalledWith('search/change-search-criteria', {
+          errors: {}
+        })
+        expect(responseStub.code).toHaveBeenCalledWith(BAD_REQUEST)
+        expect(responseStub.takeover).toHaveBeenCalled()
       })
     })
 
@@ -122,7 +140,7 @@ describe('change search criteria routes', () => {
       })
 
       test('it stores the criteria in session and redirects to /change-search-criteria', async () => {
-        await postChangeSearchCriteria.handler(request, h)
+        await postChangeSearchCriteria.options.handler(request, h)
 
         expect(request.yar.set).toHaveBeenCalledWith('changeSearchCriteria', { searchCriteria: 'sbi' })
         expect(h.redirect).toHaveBeenCalledWith('/change-search-criteria')
@@ -136,7 +154,7 @@ describe('change search criteria routes', () => {
       })
 
       test('it stores the criteria in session and redirects to /change-search-criteria', async () => {
-        await postChangeSearchCriteria.handler(request, h)
+        await postChangeSearchCriteria.options.handler(request, h)
 
         expect(request.yar.set).toHaveBeenCalledWith('changeSearchCriteria', { searchCriteria: 'crn' })
         expect(h.redirect).toHaveBeenCalledWith('/change-search-criteria')

--- a/test/unit/routes/search/change-search-criteria-routes.test.js
+++ b/test/unit/routes/search/change-search-criteria-routes.test.js
@@ -1,0 +1,147 @@
+// Test framework dependencies
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+// Test helpers
+import { BAD_REQUEST } from '../../../../src/constants/status-codes.js'
+
+// Thing under test
+import { changeSearchCriteriaRoutes } from '../../../../src/routes/search/change-search-criteria-routes.js'
+const [getChangeSearchCriteria, postChangeSearchCriteria] = changeSearchCriteriaRoutes
+
+describe('change search criteria routes', () => {
+  let request
+  let h
+  let responseStub
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    responseStub = {
+      code: vi.fn().mockReturnThis(),
+      takeover: vi.fn().mockReturnThis()
+    }
+
+    request = {
+      yar: {
+        get: vi.fn(),
+        set: vi.fn(),
+        clear: vi.fn()
+      },
+      payload: {}
+    }
+
+    h = {
+      view: vi.fn(() => responseStub),
+      redirect: vi.fn()
+    }
+  })
+
+  describe('GET /change-search-criteria', () => {
+    test('should have the correct method and path configured', () => {
+      expect(getChangeSearchCriteria.method).toBe('GET')
+      expect(getChangeSearchCriteria.path).toBe('/change-search-criteria')
+    })
+
+    describe('when no search criteria is in session', () => {
+      beforeEach(() => {
+        request.yar.get.mockReturnValue(undefined)
+      })
+
+      test('it renders the search criteria page with no page data', async () => {
+        await getChangeSearchCriteria.handler(request, h)
+
+        expect(request.yar.get).toHaveBeenCalledWith('changeSearchCriteria')
+        expect(h.view).toHaveBeenCalledWith('search/change-search-criteria')
+        expect(h.redirect).not.toHaveBeenCalled()
+        expect(request.yar.clear).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when search criteria is in session', () => {
+      describe('when the stored criteria is sbi', () => {
+        beforeEach(() => {
+          request.yar.get.mockReturnValue({ searchCriteria: 'sbi' })
+        })
+
+        test('it clears session state and redirects to /search-sbi', async () => {
+          await getChangeSearchCriteria.handler(request, h)
+
+          expect(request.yar.clear).toHaveBeenCalledWith('changeSearchCriteria')
+          expect(h.redirect).toHaveBeenCalledWith('/search-sbi')
+          expect(h.view).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('when the stored criteria is crn', () => {
+        beforeEach(() => {
+          request.yar.get.mockReturnValue({ searchCriteria: 'crn' })
+        })
+
+        test('it clears session state and redirects to /search-crn', async () => {
+          await getChangeSearchCriteria.handler(request, h)
+
+          expect(request.yar.clear).toHaveBeenCalledWith('changeSearchCriteria')
+          expect(h.redirect).toHaveBeenCalledWith('/search-crn')
+          expect(h.view).not.toHaveBeenCalled()
+        })
+      })
+    })
+  })
+
+  describe('POST /change-search-criteria', () => {
+    test('should have the correct method and path configured', () => {
+      expect(postChangeSearchCriteria.method).toBe('POST')
+      expect(postChangeSearchCriteria.path).toBe('/change-search-criteria')
+    })
+
+    describe('when no option is selected', () => {
+      beforeEach(() => {
+        request.payload = {}
+      })
+
+      test('it renders the view with a validation error and bad request status', async () => {
+        await postChangeSearchCriteria.handler(request, h)
+
+        expect(h.view).toHaveBeenCalledWith('search/change-search-criteria', {
+          errors: {
+            searchCriteria: {
+              text: 'Select what you want to search by'
+            }
+          }
+        })
+        expect(responseStub.code).toHaveBeenCalledWith(BAD_REQUEST)
+        expect(responseStub.takeover).toHaveBeenCalled()
+        expect(request.yar.set).not.toHaveBeenCalled()
+        expect(h.redirect).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when Single business identifier (SBI) is selected', () => {
+      beforeEach(() => {
+        request.payload = { searchCriteria: 'sbi' }
+      })
+
+      test('it stores the criteria in session and redirects to /change-search-criteria', async () => {
+        await postChangeSearchCriteria.handler(request, h)
+
+        expect(request.yar.set).toHaveBeenCalledWith('changeSearchCriteria', { searchCriteria: 'sbi' })
+        expect(h.redirect).toHaveBeenCalledWith('/change-search-criteria')
+        expect(h.view).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when Customer reference number (CRN) is selected', () => {
+      beforeEach(() => {
+        request.payload = { searchCriteria: 'crn' }
+      })
+
+      test('it stores the criteria in session and redirects to /change-search-criteria', async () => {
+        await postChangeSearchCriteria.handler(request, h)
+
+        expect(request.yar.set).toHaveBeenCalledWith('changeSearchCriteria', { searchCriteria: 'crn' })
+        expect(h.redirect).toHaveBeenCalledWith('/change-search-criteria')
+        expect(h.view).not.toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/test/unit/routes/search/change-search-criteria-routes.test.js
+++ b/test/unit/routes/search/change-search-criteria-routes.test.js
@@ -22,11 +22,6 @@ describe('change search criteria routes', () => {
     }
 
     request = {
-      yar: {
-        get: vi.fn(),
-        set: vi.fn(),
-        clear: vi.fn()
-      },
       payload: {}
     }
 
@@ -42,49 +37,10 @@ describe('change search criteria routes', () => {
       expect(getChangeSearchCriteria.path).toBe('/change-search-criteria')
     })
 
-    describe('when no search criteria is in session', () => {
-      beforeEach(() => {
-        request.yar.get.mockReturnValue(undefined)
-      })
+    test('it renders the search criteria page', async () => {
+      await getChangeSearchCriteria.handler(request, h)
 
-      test('it renders the search criteria page with no page data', async () => {
-        await getChangeSearchCriteria.handler(request, h)
-
-        expect(request.yar.get).toHaveBeenCalledWith('changeSearchCriteria')
-        expect(h.view).toHaveBeenCalledWith('search/change-search-criteria')
-        expect(h.redirect).not.toHaveBeenCalled()
-        expect(request.yar.clear).not.toHaveBeenCalled()
-      })
-    })
-
-    describe('when search criteria is in session', () => {
-      describe('when the stored criteria is sbi', () => {
-        beforeEach(() => {
-          request.yar.get.mockReturnValue({ searchCriteria: 'sbi' })
-        })
-
-        test('it clears session state and redirects to /search-sbi', async () => {
-          await getChangeSearchCriteria.handler(request, h)
-
-          expect(request.yar.clear).toHaveBeenCalledWith('changeSearchCriteria')
-          expect(h.redirect).toHaveBeenCalledWith('/search-sbi')
-          expect(h.view).not.toHaveBeenCalled()
-        })
-      })
-
-      describe('when the stored criteria is crn', () => {
-        beforeEach(() => {
-          request.yar.get.mockReturnValue({ searchCriteria: 'crn' })
-        })
-
-        test('it clears session state and redirects to /search-crn', async () => {
-          await getChangeSearchCriteria.handler(request, h)
-
-          expect(request.yar.clear).toHaveBeenCalledWith('changeSearchCriteria')
-          expect(h.redirect).toHaveBeenCalledWith('/search-crn')
-          expect(h.view).not.toHaveBeenCalled()
-        })
-      })
+      expect(h.view).toHaveBeenCalledWith('search/change-search-criteria')
     })
   })
 
@@ -139,11 +95,10 @@ describe('change search criteria routes', () => {
         request.payload = { searchCriteria: 'sbi' }
       })
 
-      test('it stores the criteria in session and redirects to /change-search-criteria', async () => {
+      test('it redirects to /search-sbi', async () => {
         await postChangeSearchCriteria.options.handler(request, h)
 
-        expect(request.yar.set).toHaveBeenCalledWith('changeSearchCriteria', { searchCriteria: 'sbi' })
-        expect(h.redirect).toHaveBeenCalledWith('/change-search-criteria')
+        expect(h.redirect).toHaveBeenCalledWith('/search-sbi')
         expect(h.view).not.toHaveBeenCalled()
       })
     })
@@ -153,11 +108,10 @@ describe('change search criteria routes', () => {
         request.payload = { searchCriteria: 'crn' }
       })
 
-      test('it stores the criteria in session and redirects to /change-search-criteria', async () => {
+      test('it redirects to /search-crn', async () => {
         await postChangeSearchCriteria.options.handler(request, h)
 
-        expect(request.yar.set).toHaveBeenCalledWith('changeSearchCriteria', { searchCriteria: 'crn' })
-        expect(h.redirect).toHaveBeenCalledWith('/change-search-criteria')
+        expect(h.redirect).toHaveBeenCalledWith('/search-crn')
         expect(h.view).not.toHaveBeenCalled()
       })
     })

--- a/test/unit/schemas/search/search-criteria-schema.test.js
+++ b/test/unit/schemas/search/search-criteria-schema.test.js
@@ -1,0 +1,84 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach } from 'vitest'
+
+// Thing under test
+import { searchCriteriaSchema } from '../../../../src/schemas/search/search-criteria-schema.js'
+
+describe('search criteria schema', () => {
+  let payload
+  let schema
+
+  beforeEach(() => {
+    schema = searchCriteriaSchema
+
+    payload = { searchCriteria: 'sbi' }
+  })
+
+  describe('when valid data is provided', () => {
+    test('it confirms "sbi" is valid', () => {
+      const { error, value } = schema.validate(payload, { abortEarly: false })
+
+      expect(error).toBeUndefined()
+      expect(value).toEqual(payload)
+    })
+
+    test('it confirms "crn" is valid', () => {
+      payload.searchCriteria = 'crn'
+
+      const { error, value } = schema.validate(payload, { abortEarly: false })
+
+      expect(error).toBeUndefined()
+      expect(value).toEqual(payload)
+    })
+  })
+
+  describe('when invalid data is provided', () => {
+    describe('because "searchCriteria" is missing', () => {
+      beforeEach(() => {
+        delete payload.searchCriteria
+      })
+
+      test('it fails validation', () => {
+        const { error } = schema.validate(payload, { abortEarly: false })
+
+        expect(error.details[0]).toEqual(expect.objectContaining({
+          message: 'Select what you want to search by',
+          path: ['searchCriteria'],
+          type: 'any.required'
+        }))
+      })
+    })
+
+    describe('because "searchCriteria" is empty', () => {
+      beforeEach(() => {
+        payload.searchCriteria = ''
+      })
+
+      test('it fails validation', () => {
+        const { error } = schema.validate(payload, { abortEarly: false })
+
+        expect(error.details[0]).toEqual(expect.objectContaining({
+          message: 'Select what you want to search by',
+          path: ['searchCriteria'],
+          type: 'any.only'
+        }))
+      })
+    })
+
+    describe('because "searchCriteria" is not a valid option', () => {
+      beforeEach(() => {
+        payload.searchCriteria = 'invalid'
+      })
+
+      test('it fails validation', () => {
+        const { error } = schema.validate(payload, { abortEarly: false })
+
+        expect(error.details[0]).toEqual(expect.objectContaining({
+          message: 'Select what you want to search by',
+          path: ['searchCriteria'],
+          type: 'any.only'
+        }))
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FLS2-43

## Summary

Adds the search criteria selection page (INT-SR02), which allows internal users to choose whether to search by SBI or CRN before being directed to the appropriate search page. The existing SBI and CRN search pages have also been updated to link to this new page.

## Changes

- Add `change-search-criteria` route with GET (render/redirect) and POST (validation + redirect) handlers
- Add `change-search-criteria.njk` view with GOV.UK radios (SBI / CRN), error summary, and continue button
- Update `search-sbi.njk` and `search-crn.njk` to link to the new change criteria page
- Register the new routes in `routes.js`
- Add unit tests for the new route covering the no-selection error case, SBI redirect, and CRN redirect