### PR TITLE
Fix the clear search results link in the search results page

### DIFF
--- a/src/routes/search/search-crn-routes.js
+++ b/src/routes/search/search-crn-routes.js
@@ -45,7 +45,7 @@ const postSearchCrn = {
 
     if (validation.error) {
       const errors = utils.formatValidationErrors(validation.error.details || [])
-      const pageData = { ...payload, errors }
+      const pageData = { ...payload, errors, showClear: true }
 
       return h.view(SEARCH_CRN_VIEW, pageData).code(BAD_REQUEST).takeover()
     }

--- a/src/routes/search/search-sbi-routes.js
+++ b/src/routes/search/search-sbi-routes.js
@@ -45,7 +45,7 @@ const postSearchSbi = {
 
     if (validation.error) {
       const errors = utils.formatValidationErrors(validation.error.details || [])
-      const pageData = { ...payload, errors }
+      const pageData = { ...payload, errors, showClear: true }
 
       return h.view(SEARCH_SBI_VIEW, pageData).code(BAD_REQUEST).takeover()
     }

--- a/test/unit/routes/search/search-crn-routes.test.js
+++ b/test/unit/routes/search/search-crn-routes.test.js
@@ -171,7 +171,8 @@ describe('search crn routes', () => {
             crn: {
               text: 'Enter the full CRN'
             }
-          }
+          },
+          showClear: true
         })
         expect(responseStub.code).toHaveBeenCalledWith(BAD_REQUEST)
         expect(responseStub.takeover).toHaveBeenCalled()

--- a/test/unit/routes/search/search-sbi-routes.test.js
+++ b/test/unit/routes/search/search-sbi-routes.test.js
@@ -171,7 +171,8 @@ describe('search sbi routes', () => {
             sbi: {
               text: 'SBI must be 9 digits'
             }
-          }
+          },
+          showClear: true
         })
         expect(responseStub.code).toHaveBeenCalledWith(BAD_REQUEST)
         expect(responseStub.takeover).toHaveBeenCalled()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FLS2-33
https://eaflood.atlassian.net/browse/FLS2-34

During the testing for these tickets, a new A/C that wasn't fleshed out in the ticket was identified. This A/C is to ensure that the clear search results link on the search results page is present even when invalid sbi or crn's are entered.