### PR TITLE
chore(#fls1-58): fix duplication for sonarqube

### DIFF
--- a/src/mappers/address-mapper.js
+++ b/src/mappers/address-mapper.js
@@ -1,0 +1,31 @@
+/**
+ * Maps a raw address object to a structured address format
+ *
+ * @param {Object} address - The raw address data
+ * @param {Object} [extraLookupFields={}] - Additional lookup fields to include (e.g. pafOrganisationName)
+ *
+ * @returns {Object} Formatted address data
+ */
+export const mapAddress = (address, extraLookupFields = {}) => ({
+  lookup: {
+    ...extraLookupFields,
+    buildingNumberRange: address.buildingNumberRange,
+    flatName: address.flatName,
+    buildingName: address.buildingName,
+    dependentLocality: address.dependentLocality,
+    doubleDependentLocality: address.doubleDependentLocality,
+    street: address.street,
+    county: address.county,
+    uprn: address.uprn
+  },
+  manual: {
+    line1: address.line1,
+    line2: address.line2,
+    line3: address.line3,
+    line4: address.line4,
+    line5: address.line5
+  },
+  city: address.city,
+  postcode: address.postalCode,
+  country: address.country
+})

--- a/src/mappers/business-details-by-sbi-mapper.js
+++ b/src/mappers/business-details-by-sbi-mapper.js
@@ -1,3 +1,5 @@
+import { mapAddress } from './address-mapper.js'
+
 /**
  * Takes the raw business details by sbi data and maps it to a more usable format
  *
@@ -17,28 +19,8 @@ export const mapBusinessDetailsBySbi = (value) => {
       traderNumber: info.traderNumber,
       vendorNumber: info.vendorNumber
     },
-    address: {
-      lookup: {
-        pafOrganisationName: address.pafOrganisationName,
-        buildingNumberRange: address.buildingNumberRange,
-        flatName: address.flatName,
-        buildingName: address.buildingName,
-        dependentLocality: address.dependentLocality,
-        doubleDependentLocality: address.doubleDependentLocality,
-        street: address.street,
-        county: address.county,
-        uprn: address.uprn
-      },
-      manual: {
-        line1: address.line1,
-        line2: address.line2,
-        line3: address.line3,
-        line4: address.line4,
-        line5: address.line5
-      },
-      city: address.city,
-      postcode: address.postalCode,
-      country: address.country
-    }
+    address: mapAddress(address, {
+      pafOrganisationName: address.pafOrganisationName
+    })
   }
 }

--- a/src/mappers/customer-details-by-crn-mapper.js
+++ b/src/mappers/customer-details-by-crn-mapper.js
@@ -1,3 +1,5 @@
+import { mapAddress } from './address-mapper.js'
+
 /**
  * Takes the raw customer details by CRN data and maps it to a more usable format
  *
@@ -16,27 +18,6 @@ export const mapCustomerDetailsByCrn = (value) => {
       crn: value.customer.crn,
       customerName: `${name.first} ${name.last}`
     },
-    address: {
-      lookup: {
-        buildingNumberRange: address.buildingNumberRange,
-        flatName: address.flatName,
-        buildingName: address.buildingName,
-        dependentLocality: address.dependentLocality,
-        doubleDependentLocality: address.doubleDependentLocality,
-        street: address.street,
-        county: address.county,
-        uprn: address.uprn
-      },
-      manual: {
-        line1: address.line1,
-        line2: address.line2,
-        line3: address.line3,
-        line4: address.line4,
-        line5: address.line5
-      },
-      city: address.city,
-      postcode: address.postalCode,
-      country: address.country
-    }
+    address: mapAddress(address)
   }
 }

--- a/test/unit/mappers/address-mapper.test.js
+++ b/test/unit/mappers/address-mapper.test.js
@@ -1,0 +1,95 @@
+// Test framework dependencies
+import { describe, test, expect } from 'vitest'
+
+// Thing under test
+import { mapAddress } from '../../../src/mappers/address-mapper.js'
+
+// Test helpers
+import { getMappedData as getCustomerMappedData } from '../../mocks/mock-customer-details-by-crn.js'
+import { getMappedData as getBusinessMappedData } from '../../mocks/mock-business-details-by-sbi.js'
+
+describe('address mapper', () => {
+  test('it maps all fields correctly', () => {
+    const address = {
+      buildingNumberRange: '12',
+      flatName: 'Flat 1',
+      buildingName: 'The Farm House',
+      dependentLocality: 'West Fields',
+      doubleDependentLocality: 'Rural Area',
+      street: 'Farm Lane',
+      county: 'Devon',
+      uprn: '200023456789',
+      line1: '12 Farm Lane',
+      line2: 'West Fields',
+      line3: null,
+      line4: 'Devon',
+      line5: null,
+      city: 'Exeter',
+      postalCode: 'EX1 1AA',
+      country: 'England'
+    }
+
+    const result = mapAddress(address)
+
+    expect(result).toEqual(getCustomerMappedData().address)
+  })
+
+  test('it maps extra lookup fields when provided', () => {
+    const address = {
+      pafOrganisationName: 'Herberts Lawn Mowing Ltd',
+      buildingNumberRange: '14',
+      flatName: 'Flat 2',
+      buildingName: 'The Lawn Building',
+      dependentLocality: 'Taunton Borough',
+      doubleDependentLocality: 'Chip Lane Area',
+      street: 'Chip Lane',
+      county: 'Somerset',
+      uprn: '100012345678',
+      line1: '14 Chip Lane',
+      line2: 'Taunton Sorting Office',
+      line3: null,
+      line4: 'Somerset',
+      line5: null,
+      city: 'Taunton',
+      postalCode: 'TA1 1AA',
+      country: 'England'
+    }
+
+    const result = mapAddress(address, {
+      pafOrganisationName: address.pafOrganisationName
+    })
+
+    expect(result).toEqual(getBusinessMappedData().address)
+  })
+
+  test('it maps postalCode to postcode', () => {
+    const result = mapAddress({ postalCode: 'EX1 2AB' })
+
+    expect(result.postcode).toEqual('EX1 2AB')
+  })
+
+  test('it maps an empty address object without crashing', () => {
+    const result = mapAddress({})
+
+    expect(result.lookup).toEqual({
+      buildingNumberRange: undefined,
+      flatName: undefined,
+      buildingName: undefined,
+      dependentLocality: undefined,
+      doubleDependentLocality: undefined,
+      street: undefined,
+      county: undefined,
+      uprn: undefined
+    })
+    expect(result.manual).toEqual({
+      line1: undefined,
+      line2: undefined,
+      line3: undefined,
+      line4: undefined,
+      line5: undefined
+    })
+    expect(result.city).toEqual(undefined)
+    expect(result.postcode).toEqual(undefined)
+    expect(result.country).toEqual(undefined)
+  })
+})


### PR DESCRIPTION
- this fixes duplication spotted by sonarqube
- if there had been a way to mark this warning as ignored/accepted, I would have done, but this way we won't get pinged by QA team or sonarqube going forward