### PR TITLE
Replace DAL email header feature flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,5 @@ IAHW_ENDPOINT=https://ffc-ahwr-farmer-test.azure.defra.cloud/sign-in?ssoOrgId=
 
 # Misc
 ALLOW_ERROR_VIEWS=true
+USE_DAL_TEST_EMAIL=true
+DAL_EMAIL_HEADER=Test-Email

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,6 +22,8 @@ services:
       ENTRA_CLIENT_SECRET: ${ENTRA_CLIENT_SECRET}
       ENTRA_REDIRECT_URL: http://localhost:3006/auth/sign-in-oidc
       ENTRA_SIGN_OUT_REDIRECT_URL: http://localhost:3006/auth/sign-out-oidc
+      USE_DAL_TEST_EMAIL: ${USE_DAL_TEST_EMAIL:-false}
+      DAL_EMAIL_HEADER: ${DAL_EMAIL_HEADER:-}
 
   upstream-mock:
     image: defradigital/fcp-dal-upstream-mock:0.81.0

--- a/src/config/dal.js
+++ b/src/config/dal.js
@@ -30,6 +30,12 @@ export const dalConfig = {
       default: null,
       env: 'DAL_CLIENT_SECRET',
       sensitive: true
+    },
+    emailHeader: {
+      doc: 'Email address to use for testing the DAL email header feature',
+      format: String,
+      default: null,
+      env: 'DAL_EMAIL_HEADER'
     }
   }
 }

--- a/src/config/feature-toggle.js
+++ b/src/config/feature-toggle.js
@@ -1,0 +1,10 @@
+export const featureToggleConfig = {
+  featureToggle: {
+    useDalTestEmail: {
+      doc: 'Enables the DAL test email feature',
+      format: Boolean,
+      default: false,
+      env: 'USE_DAL_TEST_EMAIL'
+    }
+  }
+}

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -4,13 +4,15 @@ import { nunjucksConfig } from './nunjucks.js'
 import { redisConfig } from './redis.js'
 import { entraConfig } from './entra.js'
 import { dalConfig } from './dal.js'
+import { featureToggleConfig } from './feature-toggle.js'
 
 const config = convict({
   ...serverConfig,
   ...nunjucksConfig,
   ...redisConfig,
   ...entraConfig,
-  ...dalConfig
+  ...dalConfig,
+  ...featureToggleConfig
 })
 
 config.validate({ allowed: 'strict' })

--- a/src/routes/auth-routes.js
+++ b/src/routes/auth-routes.js
@@ -1,6 +1,7 @@
 import { getSignOutUrl } from '../auth/get-sign-out-url.js'
 import { validateState } from '../auth/state.js'
 import { verifyToken } from '../auth/verify-token.js'
+import { config } from '../config/index.js'
 
 const signIn = {
   method: 'GET',
@@ -32,6 +33,13 @@ const signInOidc = {
     await verifyToken(token)
 
     const { sessionId, roles } = profile
+
+    // TEMPORARY CODE FOR TESTING PURPOSES ONLY - REMOVE WHEN DAL TEST EMAIL FEATURE IS NO LONGER NEEDED
+    // Check if DAL test email feature is enabled
+    if (config.get('featureToggle.useDalTestEmail')) {
+      profile.email = config.get('dalConfig.emailHeader')
+    }
+
     // Store token and all useful data in the session cache
     await request.server.app.cache.set(sessionId, {
       isAuthenticated: true,


### PR DESCRIPTION

<img width="22" height="22" alt="image" src="https://github.com/user-attachments/assets/7e99b158-96b9-4394-98b7-5aae4249aefb" />
This is a temporary PR, and the aim is for the whole PR to be reverted once the test user accounts are sorted.

https://defra-digital-team.slack.com/archives/C0B34JJBQQ3/p1781690063433209 

The DAL team recently updated the email header to use the one coming from the user request rather than replacing it with a test one. This change means that we currently do not have the correct permission levels to access the DAL endpoints in the tst environments. While this is being resolved, to unblock development work and test we are adding a feature flag to allow the email header to be replaced with a test one for now.