### PR TITLE
Fix XSS unescaped business name in HTML string

### DIFF
--- a/src/presenters/overview/business-overview-presenter.js
+++ b/src/presenters/overview/business-overview-presenter.js
@@ -5,6 +5,7 @@
 
 import { paginationPresenter } from '../pagination-presenter.js'
 import { BUSINESS_OVERVIEW_PAGE_SIZE as PAGE_SIZE } from '../../constants/pagination.js'
+import { htmlEscape } from '../../utils/html-escape.js'
 
 const businessOverviewPresenter = (businessDetails, page) => {
   const customers = businessDetails?.customers ?? []
@@ -22,7 +23,7 @@ const businessOverviewPresenter = (businessDetails, page) => {
     sbi: businessDetails?.sbi || '',
     businessName: businessDetails?.businessName || '',
     hasCustomers: totalCustomers > 0,
-    customers: formatCustomers(pagedCustomers),
+    customers: formatCustomersToRows(pagedCustomers),
     pagination,
     breadcrumbs: [
       {
@@ -115,15 +116,17 @@ const paginateCustomers = (customers, currentPage) => {
   return customers.slice(startIndex, endIndex)
 }
 
-const formatCustomer = (customer) => {
-  return {
-    fullName: buildName(customer?.firstName, customer?.lastName),
-    crn: customer?.crn ?? ''
-  }
-}
+const formatCustomersToRows = (customers = []) => {
+  const rows = customers.map((customer) => [
+    {
+      html: `<a href="/customer/${htmlEscape(customer?.crn ?? '')}" class="govuk-link govuk-link--no-visited-state">${htmlEscape(buildName(customer?.firstName, customer?.lastName))}</a>`
+    },
+    {
+      text: customer?.crn ?? ''
+    }
+  ])
 
-const formatCustomers = (customers = []) => {
-  return customers.map(formatCustomer)
+  return { rows }
 }
 
 export {

--- a/src/presenters/overview/customer-overview-presenter.js
+++ b/src/presenters/overview/customer-overview-presenter.js
@@ -5,6 +5,7 @@
 
 import { paginationPresenter } from '../pagination-presenter.js'
 import { CUSTOMER_OVERVIEW_PAGE_SIZE as PAGE_SIZE } from '../../constants/pagination.js'
+import { htmlEscape } from '../../utils/html-escape.js'
 
 const customerOverviewPresenter = (customerDetails, page) => {
   const businesses = customerDetails?.businesses ?? []
@@ -109,7 +110,7 @@ const paginateBusinesses = (businesses, currentPage) => {
 const formatBusinessesToRows = (businesses = []) => {
   const rows = businesses.map((business) => [
     {
-      html: `<a href="/business/${business?.sbi ?? ''}" class="govuk-link govuk-link--no-visited-state">${business?.name ?? ''}</a>`
+      html: `<a href="/business/${htmlEscape(business?.sbi ?? '')}" class="govuk-link govuk-link--no-visited-state">${htmlEscape(business?.name ?? '')}</a>`
     },
     {
       text: business?.sbi ?? ''

--- a/src/routes/overview/business-overview-routes.js
+++ b/src/routes/overview/business-overview-routes.js
@@ -1,5 +1,6 @@
 import { fetchBusinessOverviewDetailsService } from '../../services/overview/fetch-business-overview-details-service.js'
 import { businessOverviewPresenter } from '../../presenters/overview/business-overview-presenter.js'
+import { schemas } from '@defra/fcp-sfd-frontend-engine'
 
 const getBusinessOverview = {
   method: 'GET',
@@ -7,6 +8,12 @@ const getBusinessOverview = {
   handler: async (request, h) => {
     const { query: { page }, params, auth } = request
     const { sbi } = params
+
+    const { error } = schemas.business.sbi.validate({ sbi })
+
+    if (error) {
+      return h.redirect('/search-sbi').takeover()
+    }
 
     const email = auth.credentials?.email
     const businessDetails = await fetchBusinessOverviewDetailsService(sbi, email)

--- a/src/routes/overview/customer-overview-routes.js
+++ b/src/routes/overview/customer-overview-routes.js
@@ -1,5 +1,6 @@
 import { fetchCustomerOverviewDetailsService } from '../../services/overview/fetch-customer-overview-details-service.js'
 import { customerOverviewPresenter } from '../../presenters/overview/customer-overview-presenter.js'
+import { schemas } from '@defra/fcp-sfd-frontend-engine'
 
 const getCustomerOverview = {
   method: 'GET',
@@ -7,6 +8,12 @@ const getCustomerOverview = {
   handler: async (request, h) => {
     const { query: { page }, params, auth } = request
     const { crn } = params
+
+    const { error } = schemas.customer.crn.validate({ crn })
+
+    if (error) {
+      return h.redirect('/search-crn').takeover()
+    }
 
     const email = auth.credentials?.email
     const customerDetails = await fetchCustomerOverviewDetailsService(crn, email)

--- a/src/services/overview/fetch-business-overview-details-service.js
+++ b/src/services/overview/fetch-business-overview-details-service.js
@@ -5,6 +5,7 @@
  * @module fetchBusinessOverviewDetailsService
  */
 
+import Boom from '@hapi/boom'
 import { businessDetailsOverview } from '../../dal/queries/overview/business-details-overview.js'
 import { getDalConnector } from '../../dal/connector.js'
 import { mapBusinessOverviewDetails } from '../../mappers/overview/business-overview-details-mapper.js'
@@ -19,7 +20,7 @@ const fetchBusinessOverviewDetailsService = async (sbi, email) => {
     return mappedResponse
   }
 
-  throw new Error('Failed to retrieve business details')
+  throw Boom.notFound('Business not found')
 }
 
 export {

--- a/src/services/overview/fetch-customer-overview-details-service.js
+++ b/src/services/overview/fetch-customer-overview-details-service.js
@@ -5,6 +5,7 @@
  * @module fetchCustomerOverviewDetailsService
  */
 
+import Boom from '@hapi/boom'
 import { customerDetailsOverview } from '../../dal/queries/overview/customer-details-overview.js'
 import { getDalConnector } from '../../dal/connector.js'
 import { mapCustomerOverviewDetails } from '../../mappers/overview/customer-overview-details-mapper.js'
@@ -19,7 +20,7 @@ const fetchCustomerOverviewDetailsService = async (crn, email) => {
     return mappedResponse
   }
 
-  throw new Error('Failed to retrieve customer details')
+  throw Boom.notFound('Customer not found')
 }
 
 export {

--- a/src/utils/html-escape.js
+++ b/src/utils/html-escape.js
@@ -1,0 +1,21 @@
+/**
+ * Escapes HTML special characters to prevent XSS attacks
+ * Converts &, <, >, ", and ' to their HTML entity equivalents
+ *
+ * @module htmlEscape
+ * @param {string} text - The text to escape
+ * @returns {string} The escaped text safe for use in HTML
+ */
+const htmlEscape = (text) => {
+  const map = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  }
+
+  return String(text).replace(/[&<>"']/g, (char) => map[char])
+}
+
+export { htmlEscape }

--- a/src/views/overview/business-overview.njk
+++ b/src/views/overview/business-overview.njk
@@ -1,5 +1,6 @@
 {% extends 'common/layout.njk' %}
 
+{% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {% from "common/navigation/breadcrumbs-sign-out-link.njk" import appBreadcrumbsSignOutLink with context %}
 
@@ -26,25 +27,20 @@
   <div class="govuk-grid-row govuk-!-margin-top-5">
     <div class="govuk-grid-column-two-thirds">
       {% if hasCustomers %}
-        <table class="govuk-table">
-          <caption class="govuk-table__caption govuk-table__caption--m">Customers linked to this business</caption>
-          <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-              <th scope="col" class="govuk-table__header">Customer name</th>
-              <th scope="col" class="govuk-table__header">Customer reference number (CRN)</th>
-            </tr>
-          </thead>
-          <tbody class="govuk-table__body">
-            {% for customer in customers %}
-              <tr class="govuk-table__row">
-                <th scope="row" class="govuk-table__header">
-                  <a href="#" class="govuk-link govuk-link--no-visited-state">{{ customer.fullName }}</a>
-                </th>
-                <td class="govuk-table__cell">{{ customer.crn }}</td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
+        {{ govukTable({
+          caption: "Customers linked to this business",
+          captionClasses: "govuk-table__caption--m",
+          firstCellIsHeader: true,
+          head: [
+            {
+              text: "Customer name"
+            },
+            {
+              text: "Customer reference number (CRN)"
+            }
+          ],
+          rows: customers.rows
+        }) }}
 
         {% if pagination.numberOfPages > 1 %}
           <div class="govuk-grid-row govuk-!-margin-top-9">

--- a/test/unit/presenters/overview/business-overview-presenter.test.js
+++ b/test/unit/presenters/overview/business-overview-presenter.test.js
@@ -31,11 +31,22 @@ describe('businessOverviewPresenter', () => {
         sbi: '106705779',
         businessName: 'Herberts Lawn Mowing',
         hasCustomers: true,
-        customers: [
-          { fullName: 'Alice Smith', crn: '1100000001' },
-          { fullName: 'Bob Jones', crn: '1100000002' },
-          { fullName: 'Charlie Brown', crn: '1100000003' }
-        ],
+        customers: {
+          rows: [
+            [
+              { html: '<a href="/customer/1100000001" class="govuk-link govuk-link--no-visited-state">Alice Smith</a>' },
+              { text: '1100000001' }
+            ],
+            [
+              { html: '<a href="/customer/1100000002" class="govuk-link govuk-link--no-visited-state">Bob Jones</a>' },
+              { text: '1100000002' }
+            ],
+            [
+              { html: '<a href="/customer/1100000003" class="govuk-link govuk-link--no-visited-state">Charlie Brown</a>' },
+              { text: '1100000003' }
+            ]
+          ]
+        },
         pagination: {
           currentPageNumber: 1,
           numberOfPages: 1,
@@ -113,10 +124,19 @@ describe('businessOverviewPresenter', () => {
       test('it should return customers sorted alphabetically by full name (A to Z)', () => {
         const result = businessOverviewPresenter(data, page)
 
-        expect(result.customers).toEqual([
-          { fullName: 'Alice Smith', crn: '1100000001' },
-          { fullName: 'Bob Jones', crn: '1100000002' },
-          { fullName: 'Charlie Brown', crn: '1100000003' }
+        expect(result.customers.rows).toEqual([
+          [
+            { html: '<a href="/customer/1100000001" class="govuk-link govuk-link--no-visited-state">Alice Smith</a>' },
+            { text: '1100000001' }
+          ],
+          [
+            { html: '<a href="/customer/1100000002" class="govuk-link govuk-link--no-visited-state">Bob Jones</a>' },
+            { text: '1100000002' }
+          ],
+          [
+            { html: '<a href="/customer/1100000003" class="govuk-link govuk-link--no-visited-state">Charlie Brown</a>' },
+            { text: '1100000003' }
+          ]
         ])
       })
 
@@ -128,9 +148,15 @@ describe('businessOverviewPresenter', () => {
 
         const result = businessOverviewPresenter(data, page)
 
-        expect(result.customers).toEqual([
-          { fullName: 'Apple Grower', crn: '1100000002' },
-          { fullName: 'zebra Farmer', crn: '1100000001' }
+        expect(result.customers.rows).toEqual([
+          [
+            { html: '<a href="/customer/1100000002" class="govuk-link govuk-link--no-visited-state">Apple Grower</a>' },
+            { text: '1100000002' }
+          ],
+          [
+            { html: '<a href="/customer/1100000001" class="govuk-link govuk-link--no-visited-state">zebra Farmer</a>' },
+            { text: '1100000001' }
+          ]
         ])
       })
     })
@@ -143,7 +169,7 @@ describe('businessOverviewPresenter', () => {
       test('it should return an empty rows array', () => {
         const result = businessOverviewPresenter(data, page)
 
-        expect(result.customers).toEqual([])
+        expect(result.customers).toEqual({ rows: [] })
       })
     })
 
@@ -155,7 +181,38 @@ describe('businessOverviewPresenter', () => {
       test('it should fall back to empty strings in the row', () => {
         const result = businessOverviewPresenter(data, page)
 
-        expect(result.customers[0]).toEqual({ fullName: '', crn: '' })
+        expect(result.customers.rows[0]).toEqual([
+          { html: '<a href="/customer/" class="govuk-link govuk-link--no-visited-state"></a>' },
+          { text: '' }
+        ])
+      })
+    })
+
+    describe('when a customer name contains special HTML characters', () => {
+      test('it should escape HTML special characters in the customer name', () => {
+        data.customers = [
+          { crn: '1100000001', firstName: 'Tom & Jerry <script>alert("xss")</script>', lastName: 'Farmer' }
+        ]
+
+        const result = businessOverviewPresenter(data, page)
+
+        expect(result.customers.rows[0]).toEqual([
+          { html: '<a href="/customer/1100000001" class="govuk-link govuk-link--no-visited-state">Tom &amp; Jerry &lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt; Farmer</a>' },
+          { text: '1100000001' }
+        ])
+      })
+
+      test('it should escape single quotes in the customer name', () => {
+        data.customers = [
+          { crn: '1100000001', firstName: "O'Malley", lastName: "O'Brien" }
+        ]
+
+        const result = businessOverviewPresenter(data, page)
+
+        expect(result.customers.rows[0]).toEqual([
+          { html: '<a href="/customer/1100000001" class="govuk-link govuk-link--no-visited-state">O&#39;Malley O&#39;Brien</a>' },
+          { text: '1100000001' }
+        ])
       })
     })
   })

--- a/test/unit/presenters/overview/customer-overview-presenter.test.js
+++ b/test/unit/presenters/overview/customer-overview-presenter.test.js
@@ -179,6 +179,34 @@ describe('customerOverviewPresenter', () => {
         ])
       })
     })
+
+    describe('when a business name contains special HTML characters', () => {
+      test('it should escape HTML special characters in the business name', () => {
+        data.businesses = [
+          { name: 'Farm & Co <script>alert("xss")</script>', sbi: '123456789' }
+        ]
+
+        const result = customerOverviewPresenter(data, page)
+
+        expect(result.businesses.rows[0]).toEqual([
+          { html: '<a href="/business/123456789" class="govuk-link govuk-link--no-visited-state">Farm &amp; Co &lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;</a>' },
+          { text: '123456789' }
+        ])
+      })
+
+      test('it should escape single quotes in the business name', () => {
+        data.businesses = [
+          { name: "O'Malley's Farm", sbi: '123456789' }
+        ]
+
+        const result = customerOverviewPresenter(data, page)
+
+        expect(result.businesses.rows[0]).toEqual([
+          { html: '<a href="/business/123456789" class="govuk-link govuk-link--no-visited-state">O&#39;Malley&#39;s Farm</a>' },
+          { text: '123456789' }
+        ])
+      })
+    })
   })
 
   describe('the "breadcrumbs" property', () => {

--- a/test/unit/routes/overview/business-overview-routes.test.js
+++ b/test/unit/routes/overview/business-overview-routes.test.js
@@ -41,7 +41,8 @@ describe('business overview routes', () => {
     }
 
     h = {
-      view: vi.fn()
+      view: vi.fn(),
+      redirect: vi.fn().mockReturnValue({ takeover: vi.fn().mockReturnThis() })
     }
   })
 
@@ -122,6 +123,26 @@ describe('business overview routes', () => {
       test('the presenter and view are not called', async () => {
         await expect(getBusinessOverview.handler(request, h)).rejects.toThrow()
 
+        expect(businessOverviewPresenter).not.toHaveBeenCalled()
+        expect(h.view).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the sbi fails validation', () => {
+      beforeEach(() => {
+        request.params.sbi = 'invalid-sbi'
+      })
+
+      test('it redirects to the search-sbi page', async () => {
+        await getBusinessOverview.handler(request, h)
+
+        expect(h.redirect).toHaveBeenCalledWith('/search-sbi')
+      })
+
+      test('it does not call the service, presenter or render a view', async () => {
+        await getBusinessOverview.handler(request, h)
+
+        expect(fetchBusinessOverviewDetailsService).not.toHaveBeenCalled()
         expect(businessOverviewPresenter).not.toHaveBeenCalled()
         expect(h.view).not.toHaveBeenCalled()
       })

--- a/test/unit/routes/overview/business-overview-routes.test.js
+++ b/test/unit/routes/overview/business-overview-routes.test.js
@@ -116,12 +116,16 @@ describe('business overview routes', () => {
         fetchBusinessOverviewDetailsService.mockRejectedValue(serviceError)
       })
 
-      test('the error propagates out of the handler', async () => {
-        await expect(getBusinessOverview.handler(request, h)).rejects.toThrow('Failed to retrieve business details')
+      test('it throws the error from the service', async () => {
+        const handler = getBusinessOverview.handler(request, h)
+
+        await expect(handler).rejects.toThrow('Failed to retrieve business details')
       })
 
       test('the presenter and view are not called', async () => {
-        await expect(getBusinessOverview.handler(request, h)).rejects.toThrow()
+        const handler = getBusinessOverview.handler(request, h)
+
+        await expect(handler).rejects.toThrow()
 
         expect(businessOverviewPresenter).not.toHaveBeenCalled()
         expect(h.view).not.toHaveBeenCalled()

--- a/test/unit/routes/overview/customer-overview-routes.test.js
+++ b/test/unit/routes/overview/customer-overview-routes.test.js
@@ -41,7 +41,8 @@ describe('customer overview routes', () => {
     }
 
     h = {
-      view: vi.fn()
+      view: vi.fn(),
+      redirect: vi.fn().mockReturnValue({ takeover: vi.fn().mockReturnThis() })
     }
   })
 
@@ -107,6 +108,26 @@ describe('customer overview routes', () => {
         expect(fetchCustomerOverviewDetailsService).toHaveBeenCalledWith('1234567890', undefined)
         expect(customerOverviewPresenter).toHaveBeenCalledWith(customerDetails, '2')
         expect(h.view).toHaveBeenCalledWith('overview/customer-overview', pageData)
+      })
+    })
+
+    describe('when the crn fails validation', () => {
+      beforeEach(() => {
+        request.params.crn = 'invalid-crn'
+      })
+
+      test('it redirects to the search-crn page', async () => {
+        await getCustomerOverview.handler(request, h)
+
+        expect(h.redirect).toHaveBeenCalledWith('/search-crn')
+      })
+
+      test('it does not call the service, presenter or render a view', async () => {
+        await getCustomerOverview.handler(request, h)
+
+        expect(fetchCustomerOverviewDetailsService).not.toHaveBeenCalled()
+        expect(customerOverviewPresenter).not.toHaveBeenCalled()
+        expect(h.view).not.toHaveBeenCalled()
       })
     })
   })

--- a/test/unit/routes/overview/customer-overview-routes.test.js
+++ b/test/unit/routes/overview/customer-overview-routes.test.js
@@ -130,5 +130,28 @@ describe('customer overview routes', () => {
         expect(h.view).not.toHaveBeenCalled()
       })
     })
+
+    describe('when fetchCustomerOverviewDetailsService throws', () => {
+      const serviceError = new Error('Failed to retrieve customer details')
+
+      beforeEach(() => {
+        fetchCustomerOverviewDetailsService.mockRejectedValue(serviceError)
+      })
+
+      test('it throws the error from the service', async () => {
+        const handler = getCustomerOverview.handler(request, h)
+
+        await expect(handler).rejects.toThrow('Failed to retrieve customer details')
+      })
+
+      test('the presenter and view are not called', async () => {
+        const handler = getCustomerOverview.handler(request, h)
+
+        await expect(handler).rejects.toThrow()
+
+        expect(customerOverviewPresenter).not.toHaveBeenCalled()
+        expect(h.view).not.toHaveBeenCalled()
+      })
+    })
   })
 })

--- a/test/unit/services/overview/fetch-business-overview-details-service.test.js
+++ b/test/unit/services/overview/fetch-business-overview-details-service.test.js
@@ -1,5 +1,6 @@
 // Test framework dependencies
 import { describe, test, expect, beforeEach, vi } from 'vitest'
+import Boom from '@hapi/boom'
 
 // Things we need to mock
 import { businessDetailsOverview } from '../../../../src/dal/queries/overview/business-details-overview.js'
@@ -81,8 +82,8 @@ describe('fetchBusinessOverviewDetailsService', () => {
       mockDalConnector.query.mockResolvedValue({ data: null })
     })
 
-    test('should throw a generic error', async () => {
-      await expect(fetchBusinessOverviewDetailsService(sbi, email)).rejects.toThrowError('Failed to retrieve business details')
+    test('should throw Boom.notFound error', async () => {
+      await expect(fetchBusinessOverviewDetailsService(sbi, email)).rejects.toThrow(Boom.notFound('Business not found'))
 
       expect(mockMapBusinessOverviewDetails).not.toHaveBeenCalled()
     })

--- a/test/unit/services/overview/fetch-customer-overview-details-service.test.js
+++ b/test/unit/services/overview/fetch-customer-overview-details-service.test.js
@@ -1,5 +1,6 @@
 // Test framework dependencies
 import { describe, test, expect, beforeEach, vi } from 'vitest'
+import Boom from '@hapi/boom'
 
 // Things we need to mock
 import { customerDetailsOverview } from '../../../../src/dal/queries/overview/customer-details-overview.js'
@@ -77,8 +78,8 @@ describe('fetchCustomerOverviewDetailsService', () => {
       })
     })
 
-    test('should throw a generic error', async () => {
-      await expect(fetchCustomerOverviewDetailsService(crn, email)).rejects.toThrowError('Failed to retrieve customer details')
+    test('should throw Boom.notFound error', async () => {
+      await expect(fetchCustomerOverviewDetailsService(crn, email)).rejects.toThrow(Boom.notFound('Customer not found'))
 
       expect(mockMapCustomerOverviewDetails).not.toHaveBeenCalled()
     })

--- a/test/unit/utils/html-escape.test.js
+++ b/test/unit/utils/html-escape.test.js
@@ -1,0 +1,67 @@
+// Test framework dependencies
+import { describe, test, expect } from 'vitest'
+
+// Thing under test
+import { htmlEscape } from '../../../src/utils/html-escape.js'
+
+describe('htmlEscape', () => {
+  describe('when the text contains HTML special characters', () => {
+    test('it escapes ampersands', () => {
+      expect(htmlEscape('Marks & Spencer')).toBe('Marks &amp; Spencer')
+    })
+
+    test('it escapes less-than signs', () => {
+      expect(htmlEscape('a < b')).toBe('a &lt; b')
+    })
+
+    test('it escapes greater-than signs', () => {
+      expect(htmlEscape('a > b')).toBe('a &gt; b')
+    })
+
+    test('it escapes double quotes', () => {
+      expect(htmlEscape('say "hello"')).toBe('say &quot;hello&quot;')
+    })
+
+    test('it escapes single quotes', () => {
+      expect(htmlEscape("it's mine")).toBe('it&#39;s mine')
+    })
+
+    test('it escapes all special characters in a single string', () => {
+      expect(htmlEscape('<a href="#">Tom & Jerry\'s</a>'))
+        .toBe('&lt;a href=&quot;#&quot;&gt;Tom &amp; Jerry&#39;s&lt;/a&gt;')
+    })
+  })
+
+  describe('when the text contains a script tag (XSS attempt)', () => {
+    test('it escapes the markup so it renders as text', () => {
+      expect(htmlEscape('<script>alert("xss")</script>'))
+        .toBe('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;')
+    })
+  })
+
+  describe('when the text contains no special characters', () => {
+    test('it returns the text unchanged', () => {
+      expect(htmlEscape('Jane Smith')).toBe('Jane Smith')
+    })
+  })
+
+  describe('when the text is an empty string', () => {
+    test('it returns an empty string', () => {
+      expect(htmlEscape('')).toBe('')
+    })
+  })
+
+  describe('when the value is not a string', () => {
+    test('it coerces a number to a string', () => {
+      expect(htmlEscape(1234567890)).toBe('1234567890')
+    })
+
+    test('it coerces null to a string', () => {
+      expect(htmlEscape(null)).toBe('null')
+    })
+
+    test('it coerces undefined to a string', () => {
+      expect(htmlEscape(undefined)).toBe('undefined')
+    })
+  })
+})


### PR DESCRIPTION
https://github.com/DEFRA/fcp-sfd-frontend-internal/pull/81

During a PR review for the search crn and sbi pages, some security issues were raised. 
The issues are around unescaped characters in a HTML string which could lead to XSS attacks. 
CRN's and SBI's not being validated before the route called the handler and errors not correctly throwing when the DAL can't fetch data due to invalid SBI's and CRN's.

This PR fixes the issues.