### PR TITLE
Fix Overview Sub-Header Height Alignment and Breadcrumb Labels

### DIFF
--- a/src/presenters/overview/business-overview-presenter.js
+++ b/src/presenters/overview/business-overview-presenter.js
@@ -27,7 +27,7 @@ const businessOverviewPresenter = (businessDetails, page) => {
     pagination,
     breadcrumbs: [
       {
-        text: 'Search results',
+        text: 'Search for another business',
         href: '/search-sbi'
       }
     ]

--- a/src/presenters/overview/customer-overview-presenter.js
+++ b/src/presenters/overview/customer-overview-presenter.js
@@ -26,7 +26,7 @@ const customerOverviewPresenter = (customerDetails, page) => {
     pagination,
     breadcrumbs: [
       {
-        text: 'Search results',
+        text: 'Search for another customer',
         href: '/search-crn'
       }
     ]

--- a/src/views/common/navigation/breadcrumbs-sign-out-link.njk
+++ b/src/views/common/navigation/breadcrumbs-sign-out-link.njk
@@ -2,7 +2,7 @@
   <div class="sub-header-container govuk-!-padding-top-3 govuk-clearfix">
 
     {% if auth.isAuthenticated %}
-      <div class="login-nav login-nav-aligned{% if params.loginNavClasses %} {{ params.loginNavClasses }}{% endif %}">
+      <div class="login-nav login-nav-aligned govuk-!-margin-top-0{% if params.loginNavClasses %} {{ params.loginNavClasses }}{% endif %}">
         <ul class="login-nav__list">
           <li class="login-nav__list-item">
             <a
@@ -17,7 +17,7 @@
     {% endif %}
 
     {% if params.breadcrumbs and (params.breadcrumbs | length) %}
-      <div class="govuk-breadcrumbs" style="display: inline-block">
+      <div class="govuk-breadcrumbs govuk-!-margin-top-0" style="display: inline-block">
         <ol class="govuk-breadcrumbs__list">
           {% for item in params.breadcrumbs %}
             <li class="govuk-breadcrumbs__list-item">

--- a/test/unit/presenters/overview/business-overview-presenter.test.js
+++ b/test/unit/presenters/overview/business-overview-presenter.test.js
@@ -57,7 +57,7 @@ describe('businessOverviewPresenter', () => {
         },
         breadcrumbs: [
           {
-            text: 'Search results',
+            text: 'Search for another business',
             href: '/search-sbi'
           }
         ]
@@ -223,7 +223,7 @@ describe('businessOverviewPresenter', () => {
 
       expect(result.breadcrumbs).toEqual([
         {
-          text: 'Search results',
+          text: 'Search for another business',
           href: '/search-sbi'
         }
       ])

--- a/test/unit/presenters/overview/customer-overview-presenter.test.js
+++ b/test/unit/presenters/overview/customer-overview-presenter.test.js
@@ -53,7 +53,7 @@ describe('customerOverviewPresenter', () => {
         },
         breadcrumbs: [
           {
-            text: 'Search results',
+            text: 'Search for another customer',
             href: '/search-crn'
           }
         ]
@@ -215,7 +215,7 @@ describe('customerOverviewPresenter', () => {
 
       expect(result.breadcrumbs).toEqual([
         {
-          text: 'Search results',
+          text: 'Search for another customer',
           href: '/search-crn'
         }
       ])


### PR DESCRIPTION
## Summary

On the business-overview and customer-overview pages, the sign-out link and breadcrumb sat noticeably lower than the sign-out link on the search pages. Both the `.login-nav` wrapper and `.govuk-breadcrumbs` element carry a default `margin-top: 15px` from their own CSS, which stacked on top of the container's `govuk-!-padding-top-3` (also 15px), giving a total of 30px. The search pages only produce 15px because their sign-out link is a plain anchor with no extra top margin. Adding `govuk-!-margin-top-0` to both children aligns all overview page header elements to the same height as the search pages.

The breadcrumb link text is also updated from the generic "Search results" to contextual labels ("Search for another business" / "Search for another customer"), with tests updated accordingly.

## Changes

- `breadcrumbs-sign-out-link.njk` — add `govuk-!-margin-top-0` to the `.login-nav` and `.govuk-breadcrumbs` wrappers to remove the double-spacing caused by stacked `margin-top` values
- `business-overview-presenter.js` — update breadcrumb text from `Search results` to `Search for another business`
- `customer-overview-presenter.js` — update breadcrumb text from `Search results` to `Search for another customer`
- `business-overview-presenter.test.js` — update test assertions to reflect new breadcrumb text
- `customer-overview-presenter.test.js` — update test assertions to reflect new breadcrumb text