### PR TITLE
Remove Debug Console Logs and Disable Redis Ready Check

### DIFF
--- a/src/auth/verify-token.js
+++ b/src/auth/verify-token.js
@@ -24,8 +24,6 @@ async function verifyToken (token) {
   const pem = createPublicKey({ key: jwk, format: 'jwk' }).export({ type: 'spki', format: 'pem' })
 
   Jwt.token.verify(decoded, { key: pem, algorithm: 'RS256' })
-
-  console.log('valid')
 }
 
 export { verifyToken }

--- a/src/plugins/auth.js
+++ b/src/plugins/auth.js
@@ -10,8 +10,6 @@ export const auth = {
     register: async (server) => {
       const oidcConfig = await getOidcConfig()
 
-      console.log('OIDC Config:', oidcConfig)
-
       // Bell is a third-party plugin that provides a common interface for OAuth 2.0 authentication
       // Used to authenticate users with Entra and a pre-requisite for the Cookie authentication strategy
       // Also used for changing organisations and signing out

--- a/src/utils/caching/redis-client.js
+++ b/src/utils/caching/redis-client.js
@@ -25,6 +25,7 @@ export const buildRedisClient = (redisConfig) => {
       host,
       db,
       keyPrefix,
+      enableReadyCheck: false,
       ...credentials,
       ...tls
     })
@@ -42,6 +43,7 @@ export const buildRedisClient = (redisConfig) => {
         dnsLookup: (address, callback) => callback(null, address),
         redisOptions: {
           db,
+          enableReadyCheck: false,
           ...credentials,
           ...tls
         }

--- a/test/unit/utils/caching/redis-client.test.js
+++ b/test/unit/utils/caching/redis-client.test.js
@@ -70,7 +70,8 @@ describe('buildRedisClient', () => {
       port: 6379,
       host: 'localhost',
       db: 0,
-      keyPrefix: 'test:'
+      keyPrefix: 'test:',
+      enableReadyCheck: false
     })
     expect(Cluster).not.toHaveBeenCalled()
     expect(createLogger).toHaveBeenCalled()
@@ -95,7 +96,7 @@ describe('buildRedisClient', () => {
         keyPrefix: 'test:',
         slotsRefreshTimeout: 10000,
         dnsLookup: expect.any(Function),
-        redisOptions: { db: 0 }
+        redisOptions: { db: 0, enableReadyCheck: false }
       }
     )
     expect(Redis).not.toHaveBeenCalled()
@@ -120,6 +121,7 @@ describe('buildRedisClient', () => {
       host: 'localhost',
       db: 0,
       keyPrefix: 'test:',
+      enableReadyCheck: false,
       username: 'user',
       password: 'pass'
     })
@@ -142,6 +144,7 @@ describe('buildRedisClient', () => {
       host: 'localhost',
       db: 0,
       keyPrefix: 'test:',
+      enableReadyCheck: false,
       tls: {}
     })
   })


### PR DESCRIPTION
## Summary

Removes two leftover `console.log` debug statements from the auth layer that were emitting unstructured output at `error` level in the log aggregator. Also disables the Redis ready check (`enableReadyCheck: false`) on both standalone and cluster clients to suppress NOPERM warnings caused by the ready check attempting commands that the Redis instance does not permit.

## Changes

- Remove `console.log('OIDC Config:', oidcConfig)` from `src/plugins/auth.js`
- Remove `console.log('valid')` from `src/auth/verify-token.js`
- Set `enableReadyCheck: false` on standalone and cluster Redis client config in `src/utils/caching/redis-client.js`
- Update unit tests to assert `enableReadyCheck: false` is passed through in Redis client options