### PR TITLE
Update internal URL structure for customer and business routes

### DIFF
--- a/src/constants/pagination.js
+++ b/src/constants/pagination.js
@@ -1,2 +1,2 @@
-export const CUSTOMER_OVERVIEW_PAGE_SIZE = 20
-export const BUSINESS_OVERVIEW_PAGE_SIZE = 20
+export const CUSTOMER_PAGE_SIZE = 20
+export const BUSINESS_PAGE_SIZE = 20

--- a/src/presenters/overview/business-overview-presenter.js
+++ b/src/presenters/overview/business-overview-presenter.js
@@ -1,10 +1,10 @@
 /**
- * Formats data ready for presenting in the `/business-overview/{sbi}` page
+ * Formats data ready for presenting in the `/business/{sbi}` page
  * @module businessOverviewPresenter
  */
 
 import { paginationPresenter } from '../pagination-presenter.js'
-import { BUSINESS_OVERVIEW_PAGE_SIZE as PAGE_SIZE } from '../../constants/pagination.js'
+import { BUSINESS_PAGE_SIZE as PAGE_SIZE } from '../../constants/pagination.js'
 
 const businessOverviewPresenter = (businessDetails, page) => {
   const customers = businessDetails?.customers ?? []
@@ -13,7 +13,7 @@ const businessOverviewPresenter = (businessDetails, page) => {
   const requestedPageNumber = normalisePageNumber(page)
   const currentPage = clampPageNumber(requestedPageNumber, totalCustomers)
   const pagedCustomers = paginateCustomers(sortedCustomers, currentPage)
-  const routeURL = `/business-overview/${businessDetails?.sbi}`
+  const routeURL = `/business/${businessDetails?.sbi}`
 
   const pagination = paginationPresenter(totalCustomers, currentPage, routeURL, pagedCustomers.length, 'customers')
 

--- a/src/presenters/overview/customer-overview-presenter.js
+++ b/src/presenters/overview/customer-overview-presenter.js
@@ -1,10 +1,10 @@
 /**
- * Formats data ready for presenting in the `/customer-overview/{crn}` page
+ * Formats data ready for presenting in the `/customer/{crn}` page
  * @module customerOverviewPresenter
  */
 
 import { paginationPresenter } from '../pagination-presenter.js'
-import { CUSTOMER_OVERVIEW_PAGE_SIZE as PAGE_SIZE } from '../../constants/pagination.js'
+import { CUSTOMER_PAGE_SIZE as PAGE_SIZE } from '../../constants/pagination.js'
 
 const customerOverviewPresenter = (customerDetails, page) => {
   const businesses = customerDetails?.businesses ?? []
@@ -13,7 +13,7 @@ const customerOverviewPresenter = (customerDetails, page) => {
   const requestedPageNumber = normalisePageNumber(page)
   const currentPage = clampPageNumber(requestedPageNumber, totalBusinesses)
   const pagedBusinesses = paginateBusinesses(sortedBusinesses, currentPage)
-  const routeURL = `/customer-overview/${customerDetails?.info?.crn}`
+  const routeURL = `/customer/${customerDetails?.info?.crn}`
 
   const pagination = paginationPresenter(totalBusinesses, currentPage, routeURL, pagedBusinesses.length, 'businesses')
 

--- a/src/routes/overview/business-routes.js
+++ b/src/routes/overview/business-routes.js
@@ -4,7 +4,7 @@ import { schemas } from '@defra/fcp-sfd-frontend-engine'
 
 const getBusinessOverview = {
   method: 'GET',
-  path: '/business-overview/{sbi}',
+  path: '/business/{sbi}',
   handler: async (request, h) => {
     const { query: { page }, params, auth } = request
     const { sbi } = params

--- a/src/routes/overview/customer-routes.js
+++ b/src/routes/overview/customer-routes.js
@@ -4,7 +4,7 @@ import { schemas } from '@defra/fcp-sfd-frontend-engine'
 
 const getCustomerOverview = {
   method: 'GET',
-  path: '/customer-overview/{crn}',
+  path: '/customer/{crn}',
   handler: async (request, h) => {
     const { query: { page }, params, auth } = request
     const { crn } = params

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -10,8 +10,8 @@ import { footerRoutes } from './footer/footer-routes.js'
 import { searchSbiRoutes } from './search/search-sbi-routes.js'
 import { searchCrnRoutes } from './search/search-crn-routes.js'
 import { changeSearchCriteriaRoutes } from './search/change-search-criteria-routes.js'
-import { customerOverviewRoutes } from './overview/customer-overview-routes.js'
-import { businessOverviewRoutes } from './overview/business-overview-routes.js'
+import { customerOverviewRoutes } from './overview/customer-routes.js'
+import { businessOverviewRoutes } from './overview/business-routes.js'
 
 export const routes = [
   health,

--- a/src/views/search/search-crn.njk
+++ b/src/views/search/search-crn.njk
@@ -61,7 +61,7 @@
               <li class="govuk-!-padding-top-6">
                 <header class="govuk-!-padding-bottom-0">
                   <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
-                    <a class="govuk-link govuk-link--no-visited-state" href="/customer-overview/{{ crn }}">{{ customerName }}</a>
+                    <a class="govuk-link govuk-link--no-visited-state" href="/customer/{{ crn }}">{{ customerName }}</a>
                   </h3>
                 </header>
                 <p class="govuk-body govuk-!-margin-bottom-2">CRN: {{ crn }}</p>

--- a/src/views/search/search-sbi.njk
+++ b/src/views/search/search-sbi.njk
@@ -61,7 +61,7 @@
               <li class="govuk-!-padding-top-6">
                 <header class="govuk-!-padding-bottom-0">
                   <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
-                    <a class="govuk-link govuk-link--no-visited-state" href="/business-overview/{{ sbi }}">{{ businessName }}</a>
+                    <a class="govuk-link govuk-link--no-visited-state" href="/business/{{ sbi }}">{{ businessName }}</a>
                   </h3>
                 </header>
                 <p class="govuk-body govuk-!-margin-bottom-2">SBI: {{ sbi }}</p>

--- a/test/unit/routes/overview/business-overview-routes.test.js
+++ b/test/unit/routes/overview/business-overview-routes.test.js
@@ -6,7 +6,7 @@ import { fetchBusinessOverviewDetailsService } from '../../../../src/services/ov
 import { businessOverviewPresenter } from '../../../../src/presenters/overview/business-overview-presenter.js'
 
 // Thing under test
-import { businessOverviewRoutes } from '../../../../src/routes/overview/business-overview-routes.js'
+import { businessOverviewRoutes } from '../../../../src/routes/overview/business-routes.js'
 
 const [getBusinessOverview] = businessOverviewRoutes
 
@@ -46,10 +46,10 @@ describe('business overview routes', () => {
     }
   })
 
-  describe('GET /business-overview/{sbi}', () => {
+  describe('GET /business/{sbi}', () => {
     test('should have the correct method and path configured', () => {
       expect(getBusinessOverview.method).toBe('GET')
-      expect(getBusinessOverview.path).toBe('/business-overview/{sbi}')
+      expect(getBusinessOverview.path).toBe('/business/{sbi}')
     })
 
     describe('when auth credentials contain an email', () => {

--- a/test/unit/routes/overview/customer-overview-routes.test.js
+++ b/test/unit/routes/overview/customer-overview-routes.test.js
@@ -6,7 +6,7 @@ import { fetchCustomerOverviewDetailsService } from '../../../../src/services/ov
 import { customerOverviewPresenter } from '../../../../src/presenters/overview/customer-overview-presenter.js'
 
 // Thing under test
-import { customerOverviewRoutes } from '../../../../src/routes/overview/customer-overview-routes.js'
+import { customerOverviewRoutes } from '../../../../src/routes/overview/customer-routes.js'
 
 const [getCustomerOverview] = customerOverviewRoutes
 
@@ -46,10 +46,10 @@ describe('customer overview routes', () => {
     }
   })
 
-  describe('GET /customer-overview/{crn}', () => {
+  describe('GET /customer/{crn}', () => {
     test('should have the correct method and path configured', () => {
       expect(getCustomerOverview.method).toBe('GET')
-      expect(getCustomerOverview.path).toBe('/customer-overview/{crn}')
+      expect(getCustomerOverview.path).toBe('/customer/{crn}')
     })
 
     describe('when auth credentials contain an email', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FLS2-51
https://eaflood.atlassian.net/browse/FLS2-31

This PR updates the internal service routing to align with the agreed URL structure defined in the recent design decision.

The following routes have been updated:

**Before:**
- `/customer-overview`
- `/business-overview`

**After:**
- `/customer/${CRN}`
- `/customer/${CRN}/details`
- `/business/${SBI}`
- `/business/${SBI}/details`

This change moves the service from generic “overview” routes to resource-based URLs that directly represent the customer or business being viewed.

- Improves clarity by making URLs represent specific resources (customer or business)
- Removes reliance on shared or implicit state for selected records
- Ensures each page is independently addressable and works correctly with multiple tabs
- Aligns with the agreed decision to use CRN and SBI as path parameters
- Replaces the previous `/internal-*` and `*-overview` patterns with a cleaner, more consistent structure

- No change to underlying functionality or data
- Navigation flow remains the same, but URLs are now more explicit
- Users may notice updated URLs when navigating or bookmarking pages
- Any existing bookmarks to old overview routes will no longer work

All routes continue to be protected by existing authentication and authorisation controls. CRN and SBI values are not used for access control and remain subject to standard permission checks.