### PR TITLE
FLS1-32 View business details page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@defra/fcp-sfd-frontend-engine": "0.2.11",
+        "@defra/fcp-sfd-frontend-engine": "0.5.0",
         "@defra/hapi-tracing": "1.30.0",
         "@elastic/ecs-pino-format": "1.5.0",
         "@hapi/bell": "13.1.0",
@@ -491,9 +491,9 @@
       "license": "MIT"
     },
     "node_modules/@defra/fcp-sfd-frontend-engine": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.2.11.tgz",
-      "integrity": "sha512-Ya4hpEvPtb2uraQ3+OIsKUoQs7hbrKqk90sNuWd0zXt+IqWdBMYKspc2OKA6HivePxXXdPLbnb6e7T2C+7eObQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.5.0.tgz",
+      "integrity": "sha512-oQKXvqYKijXv272WnpSVc4BrhnNZucHxHaLYvf1xRC+nHnor6GuElNBiI9Ul4iS4RSlsJKyShUlMG1AnAxvtvA==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "joi": "18.2.1"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "license": "OGL-UK-3.0",
   "dependencies": {
-    "@defra/fcp-sfd-frontend-engine": "0.2.11",
+    "@defra/fcp-sfd-frontend-engine": "0.5.0",
     "@defra/hapi-tracing": "1.30.0",
     "@elastic/ecs-pino-format": "1.5.0",
     "@hapi/bell": "13.1.0",

--- a/src/dal/queries/business-details.js
+++ b/src/dal/queries/business-details.js
@@ -1,0 +1,48 @@
+export const businessDetailsQuery = `
+  query Business($sbi: ID!) {
+  business(sbi: $sbi) {
+    sbi
+    info {
+      name
+      vat
+      traderNumber
+      vendorNumber
+      legalStatus {
+        type
+      }
+      type {
+        type
+      }
+      address {
+        pafOrganisationName
+        buildingNumberRange
+        buildingName
+        flatName
+        street
+        city
+        county
+        postalCode
+        country
+        dependentLocality
+        doubleDependentLocality
+        line1
+        line2
+        line3
+        line4
+        line5
+        uprn
+      }
+      email {
+        address
+      }
+      phone {
+        mobile
+        landline
+      }
+    }
+    countyParishHoldings {
+      cphNumber
+    }
+  }
+}
+`

--- a/src/mappers/business-details-mapper.js
+++ b/src/mappers/business-details-mapper.js
@@ -8,38 +8,6 @@
 
 import { mappers } from '@defra/fcp-sfd-frontend-engine'
 
-const asNullable = (value) => value ?? null
-
-const mapBusinessInfo = (business) => {
-  const info = business.info ?? {}
-
-  return {
-    sbi: business.sbi,
-    businessName: asNullable(info.name),
-    vat: asNullable(info.vat),
-    traderNumber: asNullable(info.traderNumber),
-    vendorNumber: asNullable(info.vendorNumber),
-    legalStatus: asNullable(info.legalStatus?.type),
-    type: asNullable(info.type?.type),
-    countyParishHoldingNumbers: business.countyParishHoldings ?? []
-  }
-}
-
-const mapBusinessContact = (businessInfo) => {
-  return {
-    email: asNullable(businessInfo.email?.address),
-    landline: asNullable(businessInfo.phone?.landline),
-    mobile: asNullable(businessInfo.phone?.mobile)
-  }
-}
-
 export const mapBusinessDetails = (value) => {
-  const business = value.business
-  const businessInfo = business.info ?? {}
-
-  return {
-    info: mapBusinessInfo(business),
-    address: mappers.address(businessInfo.address),
-    contact: mapBusinessContact(businessInfo)
-  }
+  return mappers.businessDetails(value)
 }

--- a/src/mappers/business-details-mapper.js
+++ b/src/mappers/business-details-mapper.js
@@ -8,23 +8,38 @@
 
 import { mappers } from '@defra/fcp-sfd-frontend-engine'
 
-export const mapBusinessDetails = (value) => {
+const asNullable = (value) => value ?? null
+
+const mapBusinessInfo = (business) => {
+  const info = business.info ?? {}
+
   return {
-    info: {
-      sbi: value.business.sbi,
-      businessName: value.business.info.name ?? null,
-      vat: value.business.info.vat ?? null,
-      traderNumber: value.business.info.traderNumber ?? null,
-      vendorNumber: value.business.info.vendorNumber ?? null,
-      legalStatus: value.business.info.legalStatus?.type ?? null,
-      type: value.business.info.type?.type ?? null,
-      countyParishHoldingNumbers: value.business.countyParishHoldings ?? []
-    },
-    address: mappers.address(value.business.info.address),
-    contact: {
-      email: value.business.info.email?.address ?? null,
-      landline: value.business.info.phone?.landline ?? null,
-      mobile: value.business.info.phone?.mobile ?? null
-    }
+    sbi: business.sbi,
+    businessName: asNullable(info.name),
+    vat: asNullable(info.vat),
+    traderNumber: asNullable(info.traderNumber),
+    vendorNumber: asNullable(info.vendorNumber),
+    legalStatus: asNullable(info.legalStatus?.type),
+    type: asNullable(info.type?.type),
+    countyParishHoldingNumbers: business.countyParishHoldings ?? []
+  }
+}
+
+const mapBusinessContact = (businessInfo) => {
+  return {
+    email: asNullable(businessInfo.email?.address),
+    landline: asNullable(businessInfo.phone?.landline),
+    mobile: asNullable(businessInfo.phone?.mobile)
+  }
+}
+
+export const mapBusinessDetails = (value) => {
+  const business = value.business
+  const businessInfo = business.info ?? {}
+
+  return {
+    info: mapBusinessInfo(business),
+    address: mappers.address(businessInfo.address),
+    contact: mapBusinessContact(businessInfo)
   }
 }

--- a/src/mappers/business-details-mapper.js
+++ b/src/mappers/business-details-mapper.js
@@ -1,0 +1,30 @@
+/**
+ * Takes the raw business data from the DAL and maps it to a more usable format
+ *
+ * @param {Object} value - The data from the DAL
+ *
+ * @returns {Object} Formatted business details data
+ */
+
+import { mappers } from '@defra/fcp-sfd-frontend-engine'
+
+export const mapBusinessDetails = (value) => {
+  return {
+    info: {
+      sbi: value.business.sbi,
+      businessName: value.business.info.name ?? null,
+      vat: value.business.info.vat ?? null,
+      traderNumber: value.business.info.traderNumber ?? null,
+      vendorNumber: value.business.info.vendorNumber ?? null,
+      legalStatus: value.business.info.legalStatus?.type ?? null,
+      type: value.business.info.type?.type ?? null,
+      countyParishHoldingNumbers: value.business.countyParishHoldings ?? []
+    },
+    address: mappers.address(value.business.info.address),
+    contact: {
+      email: value.business.info.email?.address ?? null,
+      landline: value.business.info.phone?.landline ?? null,
+      mobile: value.business.info.phone?.mobile ?? null
+    }
+  }
+}

--- a/src/presenters/base-presenter.js
+++ b/src/presenters/base-presenter.js
@@ -62,3 +62,59 @@ export const formatAddressLines = (address) => {
     postcode: postcode || ''
   }
 }
+
+/**
+ * Formats an address object into an array of display lines suitable for
+ * iterating in a template (one <div> per line).
+ *
+ * Returns an empty array when the address is absent or has no content.
+ *
+ * @param {Object} address - The address object from the mapped DAL response
+ *
+ * @returns {string[]}
+ */
+export const formatDisplayAddress = (address) => {
+  if (!address) {
+    return []
+  }
+
+  const lookup = address.lookup || {}
+  const manual = address.manual || {}
+  const postcode = address.postcode || ''
+  const country = address.country || ''
+  const city = address.city || ''
+
+  let lines = []
+
+  if (lookup.uprn) {
+    const buildingAndStreet = [lookup.buildingNumberRange, lookup.street]
+      .filter(Boolean)
+      .join(' ')
+
+    lines = [
+      lookup.pafOrganisationName,
+      lookup.flatName,
+      lookup.buildingName,
+      buildingAndStreet,
+      lookup.doubleDependentLocality,
+      lookup.dependentLocality,
+      city,
+      lookup.county,
+      country,
+      postcode
+    ]
+  } else {
+    lines = [
+      manual.line1,
+      manual.line2,
+      manual.line3,
+      city,
+      manual.line4,
+      manual.line5,
+      country,
+      postcode
+    ]
+  }
+
+  return lines.filter(Boolean)
+}

--- a/src/presenters/base-presenter.js
+++ b/src/presenters/base-presenter.js
@@ -2,6 +2,41 @@
  * Base presenter for formatting data for display
  */
 
+const getAddressParts = (address) => {
+  const lookup = address.lookup || {}
+  const manual = address.manual || {}
+  const city = address.city || ''
+  const country = address.country || ''
+
+  if (lookup.uprn) {
+    const buildingAndStreet = [lookup.buildingNumberRange, lookup.street]
+      .filter(Boolean)
+      .join(' ')
+
+    return [
+      lookup.pafOrganisationName,
+      lookup.flatName,
+      lookup.buildingName,
+      buildingAndStreet,
+      lookup.doubleDependentLocality,
+      lookup.dependentLocality,
+      city,
+      lookup.county,
+      country
+    ]
+  }
+
+  return [
+    manual.line1,
+    manual.line2,
+    manual.line3,
+    city,
+    manual.line4, // County
+    manual.line5,
+    country
+  ]
+}
+
 /**
  * Formats an address object into a comma-separated address string and a separate postcode.
  *
@@ -19,43 +54,8 @@ export const formatAddressLines = (address) => {
     return { addressLines: '', postcode: '' }
   }
 
-  const lookup = address.lookup || {}
-  const manual = address.manual || {}
   const postcode = address.postcode || ''
-  const country = address.country || ''
-  const city = address.city || ''
-
-  let lines = []
-
-  if (lookup.uprn) {
-    // The user selected an address from the lookup tool
-    const buildingAndStreet = [lookup.buildingNumberRange, lookup.street]
-      .filter(Boolean)
-      .join(' ')
-
-    lines = [
-      lookup.pafOrganisationName,
-      lookup.flatName,
-      lookup.buildingName,
-      buildingAndStreet,
-      lookup.doubleDependentLocality,
-      lookup.dependentLocality,
-      city,
-      lookup.county,
-      country
-    ]
-  } else {
-    // The user typed their address in manually
-    lines = [
-      manual.line1,
-      manual.line2,
-      manual.line3,
-      city,
-      manual.line4, // County
-      manual.line5,
-      country
-    ]
-  }
+  const lines = getAddressParts(address)
 
   return {
     addressLines: lines.filter(Boolean).join(', '),
@@ -78,43 +78,8 @@ export const formatDisplayAddress = (address) => {
     return []
   }
 
-  const lookup = address.lookup || {}
-  const manual = address.manual || {}
   const postcode = address.postcode || ''
-  const country = address.country || ''
-  const city = address.city || ''
-
-  let lines = []
-
-  if (lookup.uprn) {
-    const buildingAndStreet = [lookup.buildingNumberRange, lookup.street]
-      .filter(Boolean)
-      .join(' ')
-
-    lines = [
-      lookup.pafOrganisationName,
-      lookup.flatName,
-      lookup.buildingName,
-      buildingAndStreet,
-      lookup.doubleDependentLocality,
-      lookup.dependentLocality,
-      city,
-      lookup.county,
-      country,
-      postcode
-    ]
-  } else {
-    lines = [
-      manual.line1,
-      manual.line2,
-      manual.line3,
-      city,
-      manual.line4,
-      manual.line5,
-      country,
-      postcode
-    ]
-  }
+  const lines = [...getAddressParts(address), postcode]
 
   return lines.filter(Boolean)
 }

--- a/src/presenters/base-presenter.js
+++ b/src/presenters/base-presenter.js
@@ -62,24 +62,3 @@ export const formatAddressLines = (address) => {
     postcode: postcode || ''
   }
 }
-
-/**
- * Formats an address object into an array of display lines suitable for
- * iterating in a template (one <div> per line).
- *
- * Returns an empty array when the address is absent or has no content.
- *
- * @param {Object} address - The address object from the mapped DAL response
- *
- * @returns {string[]}
- */
-export const formatDisplayAddress = (address) => {
-  if (!address) {
-    return []
-  }
-
-  const postcode = address.postcode || ''
-  const lines = [...getAddressParts(address), postcode]
-
-  return lines.filter(Boolean)
-}

--- a/src/presenters/business/business-details-presenter.js
+++ b/src/presenters/business/business-details-presenter.js
@@ -5,8 +5,13 @@
 
 import { formatDisplayAddress } from '../base-presenter.js'
 
+const CHANGE_LINK = '#'
+
 const businessDetailsPresenter = (data, sbi) => {
-  const countyParishHoldingNumbers = formatCph(data.info.countyParishHoldingNumbers)
+  const { info, address, contact } = data
+  const countyParishHoldingNumbers = formatCph(info.countyParishHoldingNumbers)
+  const addressLines = formatAddress(address)
+  const hasAddress = addressLines.length > 0
 
   return {
     pageTitle: 'View business details',
@@ -22,46 +27,21 @@ const businessDetailsPresenter = (data, sbi) => {
         href: `/business/${sbi}`
       }
     ],
-    businessName: {
-      value: data.info.businessName || 'Not added',
-      action: getActionText(data.info.businessName),
-      changeLink: '#'
-    },
+    businessName: createEditableValueField(info.businessName, 'Not added'),
     businessAddress: {
-      value: formatAddress(data.address),
-      action: getActionText(data.address?.lookup?.uprn || data.address?.manual?.line1),
-      changeLink: '#'
+      value: hasAddress ? addressLines : 'Not added',
+      action: getActionText(hasAddress),
+      changeLink: CHANGE_LINK
     },
-    businessTelephone: {
-      telephone: data.contact.landline || 'Not added',
-      mobile: data.contact.mobile || 'Not added',
-      action: getActionText(data.contact.landline || data.contact.mobile),
-      changeLink: '#'
-    },
-    businessEmail: {
-      value: data.contact.email || 'Not added',
-      action: getActionText(data.contact.email),
-      changeLink: '#'
-    },
-    vatNumber: {
-      value: data.info.vat || 'No number added',
-      action: getActionText(data.info.vat),
-      changeLink: '#'
-    },
-    tradeNumber: data.info.traderNumber ?? null,
-    vendorRegistrationNumber: data.info.vendorNumber ?? null,
+    businessTelephone: createEditableTelephoneField(contact.landline, contact.mobile),
+    businessEmail: createEditableValueField(contact.email, 'Not added'),
+    vatNumber: createEditableValueField(info.vat, 'No number added'),
+    tradeNumber: info.traderNumber ?? null,
+    vendorRegistrationNumber: info.vendorNumber ?? null,
     countyParishHoldingNumbers,
     countyParishHoldingNumbersText: `County Parish Holding (CPH) number${countyParishHoldingNumbers.length > 1 ? 's' : ''}`,
-    businessLegalStatus: {
-      value: data.info.legalStatus ?? 'Not added',
-      action: getActionText(data.info.legalStatus),
-      changeLink: '#'
-    },
-    businessType: {
-      value: data.info.type ?? 'Not added',
-      action: getActionText(data.info.type),
-      changeLink: '#'
-    }
+    businessLegalStatus: createEditableValueField(info.legalStatus, 'Not added'),
+    businessType: createEditableValueField(info.type, 'Not added')
   }
 }
 
@@ -70,7 +50,26 @@ const formatAddress = (businessAddress) => {
     return formatDisplayAddress(businessAddress)
   }
 
-  return 'Not added'
+  return []
+}
+
+const createEditableValueField = (value, emptyValueText) => {
+  return {
+    value: value || emptyValueText,
+    action: getActionText(value),
+    changeLink: CHANGE_LINK
+  }
+}
+
+const createEditableTelephoneField = (landline, mobile) => {
+  const hasTelephone = Boolean(landline || mobile)
+
+  return {
+    telephone: landline || 'Not added',
+    mobile: mobile || 'Not added',
+    action: getActionText(hasTelephone),
+    changeLink: CHANGE_LINK
+  }
 }
 
 const getActionText = (value) => {

--- a/src/presenters/business/business-details-presenter.js
+++ b/src/presenters/business/business-details-presenter.js
@@ -11,12 +11,17 @@ const businessDetailsPresenter = (data, sbi) => {
   return {
     pageTitle: 'View business details',
     metaDescription: 'View business details.',
-    businessNameHeader: data.info.businessName ?? null,
     sbi,
-    backLink: {
-      backLink: true,
-      href: `/business-overview/${sbi}`
-    },
+    breadcrumbs: [
+      {
+        text: 'Search results',
+        href: `/search-sbi?sbi=${sbi}`
+      },
+      {
+        text: formatOverviewBreadcrumb(data.info.businessName, sbi),
+        href: `/business/${sbi}`
+      }
+    ],
     businessName: {
       value: data.info.businessName || 'Not added',
       action: getActionText(data.info.businessName),
@@ -70,6 +75,10 @@ const formatAddress = (businessAddress) => {
 
 const getActionText = (value) => {
   return value ? 'Change' : 'Add'
+}
+
+const formatOverviewBreadcrumb = (businessName, sbi) => {
+  return businessName ? `${businessName} (SBI: ${sbi})` : `SBI: ${sbi}`
 }
 
 const formatCph = (countyParishHoldings) => {

--- a/src/presenters/business/business-details-presenter.js
+++ b/src/presenters/business/business-details-presenter.js
@@ -1,0 +1,83 @@
+/**
+ * Formats data ready for presenting in the `/business/{sbi}/details` page
+ * @module businessDetailsPresenter
+ */
+
+import { formatDisplayAddress } from '../base-presenter.js'
+
+const businessDetailsPresenter = (data, sbi) => {
+  const countyParishHoldingNumbers = formatCph(data.info.countyParishHoldingNumbers)
+
+  return {
+    pageTitle: 'View business details',
+    metaDescription: 'View business details.',
+    businessNameHeader: data.info.businessName ?? null,
+    sbi,
+    backLink: {
+      backLink: true,
+      href: `/business-overview/${sbi}`
+    },
+    businessName: {
+      value: data.info.businessName || 'Not added',
+      action: getActionText(data.info.businessName),
+      changeLink: '#'
+    },
+    businessAddress: {
+      value: formatAddress(data.address),
+      action: getActionText(data.address?.lookup?.uprn || data.address?.manual?.line1),
+      changeLink: '#'
+    },
+    businessTelephone: {
+      telephone: data.contact.landline || 'Not added',
+      mobile: data.contact.mobile || 'Not added',
+      action: getActionText(data.contact.landline || data.contact.mobile),
+      changeLink: '#'
+    },
+    businessEmail: {
+      value: data.contact.email || 'Not added',
+      action: getActionText(data.contact.email),
+      changeLink: '#'
+    },
+    vatNumber: {
+      value: data.info.vat || 'No number added',
+      action: getActionText(data.info.vat),
+      changeLink: '#'
+    },
+    tradeNumber: data.info.traderNumber ?? null,
+    vendorRegistrationNumber: data.info.vendorNumber ?? null,
+    countyParishHoldingNumbers,
+    countyParishHoldingNumbersText: `County Parish Holding (CPH) number${countyParishHoldingNumbers.length > 1 ? 's' : ''}`,
+    businessLegalStatus: {
+      value: data.info.legalStatus ?? 'Not added',
+      action: getActionText(data.info.legalStatus),
+      changeLink: '#'
+    },
+    businessType: {
+      value: data.info.type ?? 'Not added',
+      action: getActionText(data.info.type),
+      changeLink: '#'
+    }
+  }
+}
+
+const formatAddress = (businessAddress) => {
+  if (businessAddress?.lookup?.uprn || businessAddress?.manual?.line1) {
+    return formatDisplayAddress(businessAddress)
+  }
+
+  return 'Not added'
+}
+
+const getActionText = (value) => {
+  return value ? 'Change' : 'Add'
+}
+
+const formatCph = (countyParishHoldings) => {
+  return (countyParishHoldings || [])
+    .filter((cph) => cph?.cphNumber)
+    .map((cph) => cph.cphNumber)
+}
+
+export {
+  businessDetailsPresenter
+}

--- a/src/presenters/business/business-details-presenter.js
+++ b/src/presenters/business/business-details-presenter.js
@@ -3,19 +3,19 @@
  * @module businessDetailsPresenter
  */
 
-import { formatDisplayAddress } from '../base-presenter.js'
+import { presenters } from '@defra/fcp-sfd-frontend-engine'
 
 const CHANGE_LINK = '#'
 
 const businessDetailsPresenter = (data, sbi) => {
   const { info, address, contact } = data
-  const countyParishHoldingNumbers = formatCph(info.countyParishHoldingNumbers)
-  const addressLines = formatAddress(address)
+  const countyParishHoldingNumbers = presenters.formatCph(info.countyParishHoldingNumbers)
+  const addressLines = presenters.formatBusinessAddress(address)
   const hasAddress = addressLines.length > 0
 
   return {
-    pageTitle: 'View business details',
-    metaDescription: 'View business details.',
+    pageTitle: 'View and update your business details',
+    metaDescription: 'View and update your business details.',
     sbi,
     breadcrumbs: [
       {
@@ -30,7 +30,7 @@ const businessDetailsPresenter = (data, sbi) => {
     businessName: createEditableValueField(info.businessName, 'Not added'),
     businessAddress: {
       value: hasAddress ? addressLines : 'Not added',
-      action: getActionText(hasAddress),
+      action: presenters.getActionText(hasAddress),
       changeLink: CHANGE_LINK
     },
     businessTelephone: createEditableTelephoneField(contact.landline, contact.mobile),
@@ -39,24 +39,16 @@ const businessDetailsPresenter = (data, sbi) => {
     tradeNumber: info.traderNumber ?? null,
     vendorRegistrationNumber: info.vendorNumber ?? null,
     countyParishHoldingNumbers,
-    countyParishHoldingNumbersText: `County Parish Holding (CPH) number${countyParishHoldingNumbers.length > 1 ? 's' : ''}`,
+    countyParishHoldingNumbersText: presenters.formatCphText(countyParishHoldingNumbers.length),
     businessLegalStatus: createEditableValueField(info.legalStatus, 'Not added'),
     businessType: createEditableValueField(info.type, 'Not added')
   }
 }
 
-const formatAddress = (businessAddress) => {
-  if (businessAddress?.lookup?.uprn || businessAddress?.manual?.line1) {
-    return formatDisplayAddress(businessAddress)
-  }
-
-  return []
-}
-
 const createEditableValueField = (value, emptyValueText) => {
   return {
     value: value || emptyValueText,
-    action: getActionText(value),
+    action: presenters.getActionText(value),
     changeLink: CHANGE_LINK
   }
 }
@@ -67,23 +59,13 @@ const createEditableTelephoneField = (landline, mobile) => {
   return {
     telephone: landline || 'Not added',
     mobile: mobile || 'Not added',
-    action: getActionText(hasTelephone),
+    action: presenters.getActionText(hasTelephone),
     changeLink: CHANGE_LINK
   }
 }
 
-const getActionText = (value) => {
-  return value ? 'Change' : 'Add'
-}
-
 const formatOverviewBreadcrumb = (businessName, sbi) => {
   return businessName ? `${businessName} (SBI: ${sbi})` : `SBI: ${sbi}`
-}
-
-const formatCph = (countyParishHoldings) => {
-  return (countyParishHoldings || [])
-    .filter((cph) => cph?.cphNumber)
-    .map((cph) => cph.cphNumber)
 }
 
 export {

--- a/src/presenters/overview/business-overview-presenter.js
+++ b/src/presenters/overview/business-overview-presenter.js
@@ -21,6 +21,7 @@ const businessOverviewPresenter = (businessDetails, page) => {
     pageTitle: 'Business overview',
     sbi: businessDetails?.sbi || '',
     businessName: businessDetails?.businessName || '',
+    businessDetailsLink: `/business/${businessDetails?.sbi}/details`,
     hasCustomers: totalCustomers > 0,
     customers: formatCustomers(pagedCustomers),
     pagination,

--- a/src/presenters/overview/business-overview-presenter.js
+++ b/src/presenters/overview/business-overview-presenter.js
@@ -26,8 +26,8 @@ const businessOverviewPresenter = (businessDetails, page) => {
     pagination,
     breadcrumbs: [
       {
-        text: 'Search for another business',
-        href: '/search-sbi'
+        text: 'Search results',
+        href: `/search-sbi?sbi=${businessDetails?.sbi}`
       }
     ]
   }

--- a/src/routes/auth-routes.js
+++ b/src/routes/auth-routes.js
@@ -24,6 +24,8 @@ const signInOidc = {
     // If the user is not authenticated, redirect to the home page
     // This should only occur if the user tries to access the sign-in page directly and not part of the sign-in flow
     // eg if the user has bookmarked the Entra sign-in page or they have signed out and tried to go back in the browser
+    console.log('request.auth:', request.auth)
+    console.log('HELLLOOOOO')
     if (!request.auth.isAuthenticated) {
       return h.view('unauthorised')
     }
@@ -34,11 +36,16 @@ const signInOidc = {
 
     const { sessionId, roles } = profile
 
+    console.log('🪵 | roles:', roles)
+    console.log('🪵 | sessionId:', sessionId)
+
     // TEMPORARY CODE FOR TESTING PURPOSES ONLY - REMOVE WHEN DAL TEST EMAIL FEATURE IS NO LONGER NEEDED
     // Check if DAL test email feature is enabled
     if (config.get('featureToggle.useDalTestEmail')) {
       profile.email = config.get('dalConfig.emailHeader')
     }
+
+    console.log('profile email:', profile.email)
 
     // Store token and all useful data in the session cache
     await request.server.app.cache.set(sessionId, {

--- a/src/routes/auth-routes.js
+++ b/src/routes/auth-routes.js
@@ -24,8 +24,6 @@ const signInOidc = {
     // If the user is not authenticated, redirect to the home page
     // This should only occur if the user tries to access the sign-in page directly and not part of the sign-in flow
     // eg if the user has bookmarked the Entra sign-in page or they have signed out and tried to go back in the browser
-    console.log('request.auth:', request.auth)
-    console.log('HELLLOOOOO')
     if (!request.auth.isAuthenticated) {
       return h.view('unauthorised')
     }
@@ -36,16 +34,11 @@ const signInOidc = {
 
     const { sessionId, roles } = profile
 
-    console.log('🪵 | roles:', roles)
-    console.log('🪵 | sessionId:', sessionId)
-
     // TEMPORARY CODE FOR TESTING PURPOSES ONLY - REMOVE WHEN DAL TEST EMAIL FEATURE IS NO LONGER NEEDED
     // Check if DAL test email feature is enabled
     if (config.get('featureToggle.useDalTestEmail')) {
       profile.email = config.get('dalConfig.emailHeader')
     }
-
-    console.log('profile email:', profile.email)
 
     // Store token and all useful data in the session cache
     await request.server.app.cache.set(sessionId, {

--- a/src/routes/business/business-details-routes.js
+++ b/src/routes/business/business-details-routes.js
@@ -1,0 +1,28 @@
+import { fetchBusinessDetailsService } from '../../services/business/fetch-business-details-service.js'
+import { businessDetailsPresenter } from '../../presenters/business/business-details-presenter.js'
+import { schemas } from '@defra/fcp-sfd-frontend-engine'
+
+const getBusinessDetails = {
+  method: 'GET',
+  path: '/business/{sbi}/details',
+  handler: async (request, h) => {
+    const { params, auth } = request
+    const { sbi } = params
+
+    const { error } = schemas.business.sbi.validate({ sbi })
+
+    if (error) {
+      return h.redirect('/search-sbi').takeover()
+    }
+
+    const email = auth.credentials?.email
+    const businessDetails = await fetchBusinessDetailsService(sbi, email)
+    const pageData = businessDetailsPresenter(businessDetails, sbi)
+
+    return h.view('business/business-details', pageData)
+  }
+}
+
+export const businessDetailsRoutes = [
+  getBusinessDetails
+]

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -12,6 +12,7 @@ import { searchCrnRoutes } from './search/search-crn-routes.js'
 import { changeSearchCriteriaRoutes } from './search/change-search-criteria-routes.js'
 import { customerOverviewRoutes } from './overview/customer-overview-routes.js'
 import { businessOverviewRoutes } from './overview/business-overview-routes.js'
+import { businessDetailsRoutes } from './business/business-details-routes.js'
 
 export const routes = [
   health,
@@ -27,5 +28,6 @@ export const routes = [
   ...searchCrnRoutes,
   ...changeSearchCriteriaRoutes,
   ...customerOverviewRoutes,
-  ...businessOverviewRoutes
+  ...businessOverviewRoutes,
+  ...businessDetailsRoutes
 ]

--- a/src/routes/search/search-sbi-routes.js
+++ b/src/routes/search/search-sbi-routes.js
@@ -12,11 +12,18 @@ const getSearchSbi = {
   method: 'GET',
   path: SEARCH_SBI_PATH,
   handler: async (request, h) => {
-    const searchState = request.yar.get(SEARCH_SBI_SESSION_KEY)
+    const sessionState = request.yar.get(SEARCH_SBI_SESSION_KEY)
 
     // Requests sent to the /search page might be either to just show the search page or to view search results,
     // so we need to check whether this is just an initial request to display the page or whether it is a request for a
-    // page of results
+    // page of results. The SBI can arrive via session (after a POST) or via query string (e.g. "Search results" link).
+    const sbiFromQuery = request.query?.sbi?.trim() ?? ''
+    const { error, value } = sbiFromQuery
+      ? schemas.business.sbi.validate({ sbi: sbiFromQuery })
+      : { error: null, value: null }
+
+    const searchState = sessionState ?? (value ? { sbi: value.sbi } : null)
+
     if (!searchState) {
       return h.view(SEARCH_SBI_VIEW)
     }

--- a/src/routes/search/search-sbi-routes.js
+++ b/src/routes/search/search-sbi-routes.js
@@ -18,9 +18,9 @@ const getSearchSbi = {
     // so we need to check whether this is just an initial request to display the page or whether it is a request for a
     // page of results. The SBI can arrive via session (after a POST) or via query string (e.g. "Search results" link).
     const sbiFromQuery = request.query?.sbi?.trim() ?? ''
-    const { error, value } = sbiFromQuery
+    const { value } = sbiFromQuery
       ? schemas.business.sbi.validate({ sbi: sbiFromQuery })
-      : { error: null, value: null }
+      : { value: null }
 
     const searchState = sessionState ?? (value ? { sbi: value.sbi } : null)
 

--- a/src/services/business/fetch-business-details-service.js
+++ b/src/services/business/fetch-business-details-service.js
@@ -1,0 +1,28 @@
+/**
+ * Returns the business details for the given SBI by querying the DAL, mapping
+ * the response and returning the mapped payload
+ *
+ * @module fetchBusinessDetailsService
+ */
+
+import Boom from '@hapi/boom'
+import { businessDetailsQuery } from '../../dal/queries/business-details.js'
+import { getDalConnector } from '../../dal/connector.js'
+import { mapBusinessDetails } from '../../mappers/business-details-mapper.js'
+
+const fetchBusinessDetailsService = async (sbi, email) => {
+  const dalConnector = getDalConnector()
+  const dalResponse = await dalConnector.query(businessDetailsQuery, { sbi }, email)
+
+  if (dalResponse.data) {
+    const mappedResponse = mapBusinessDetails(dalResponse.data)
+
+    return mappedResponse
+  }
+
+  throw Boom.notFound('Business not found')
+}
+
+export {
+  fetchBusinessDetailsService
+}

--- a/src/views/business/business-details.njk
+++ b/src/views/business/business-details.njk
@@ -1,12 +1,10 @@
 {% extends 'common/layout.njk' %}
 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
-{% from "common/sub-header/macro.njk" import subHeader %}
-{% from "common/navigation/back-sign-out-link.njk" import appBackSignOutLink with context %}
+{% from "common/navigation/breadcrumbs-sign-out-link.njk" import appBreadcrumbsSignOutLink with context %}
 
 {% block beforeContent %}
-  {{ subHeader(businessName=businessNameHeader, sbi=sbi) }}
-  {{ appBackSignOutLink(backLink) }}
+  {{ appBreadcrumbsSignOutLink({ breadcrumbs: breadcrumbs }) }}
 {% endblock %}
 
 {% block content %}

--- a/src/views/business/business-details.njk
+++ b/src/views/business/business-details.njk
@@ -8,7 +8,8 @@
 {% endblock %}
 
 {% block content %}
-<div class="govuk-grid-row">
+<div class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     <h1 class="govuk-heading-l">
@@ -258,6 +259,7 @@
       ]
     }) }}
 
+  </div>
   </div>
 </div>
 {% endblock %}

--- a/src/views/business/business-details.njk
+++ b/src/views/business/business-details.njk
@@ -1,0 +1,265 @@
+{% extends 'common/layout.njk' %}
+
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "common/sub-header/macro.njk" import subHeader %}
+{% from "common/navigation/back-sign-out-link.njk" import appBackSignOutLink with context %}
+
+{% block beforeContent %}
+  {{ subHeader(businessName=businessNameHeader, sbi=sbi) }}
+  {{ appBackSignOutLink(backLink) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">
+      {{ pageTitle }}
+    </h1>
+
+    {% set displayBusinessName %}
+      {% if businessName.value === 'Not added' %}
+        <div><span class="govuk-hint display-inline">Not added</span></div>
+      {% else %}
+        <div>{{ businessName.value }}</div>
+      {% endif %}
+    {% endset %}
+
+    {% set displayBusinessEmail %}
+      {% if businessEmail.value === 'Not added' %}
+        <div><span class="govuk-hint display-inline">Not added</span></div>
+      {% else %}
+        <div>{{ businessEmail.value }}</div>
+      {% endif %}
+    {% endset %}
+
+    {% set formattedAddress %}
+      {% if businessAddress.value === 'Not added' %}
+        <div><span class="govuk-hint display-inline">Not added</span></div>
+      {% else %}
+        {% for addressLine in businessAddress.value %}
+          <div>{{ addressLine }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endset %}
+
+    {% set formattedCph %}
+      {% for cphNumber in countyParishHoldingNumbers %}
+        <div>{{ cphNumber }}</div>
+      {% endfor %}
+    {% endset %}
+
+    {% set displayBusinessTelephone %}
+      <div>
+        Telephone:
+        {% if businessTelephone.telephone === 'Not added' %}
+          <span class="govuk-hint display-inline">{{ businessTelephone.telephone }}</span>
+        {% else %}
+          <span>{{ businessTelephone.telephone }}</span>
+        {% endif %}
+      </div>
+      <div>
+        Mobile:
+        {% if businessTelephone.mobile === 'Not added' %}
+          <span class="govuk-hint display-inline">{{ businessTelephone.mobile }}</span>
+        {% else %}
+          <span>{{ businessTelephone.mobile }}</span>
+        {% endif %}
+      </div>
+    {% endset %}
+
+    {% set displayVatNumber %}
+      {% if vatNumber.value === 'No number added' %}
+        <span class="govuk-hint display-inline">{{ vatNumber.value }}</span>
+      {% else %}
+        <span>{{ vatNumber.value }}</span>
+      {% endif %}
+    {% endset %}
+
+    <h2 class="govuk-heading-m">
+      Business contact details
+    </h2>
+
+    {% set businessNameActions = {
+      items: [
+        {
+          href: businessName.changeLink,
+          text: businessName.action,
+          visuallyHiddenText: "Business name",
+          classes: "govuk-link--no-visited-state"
+        }
+      ]
+    } %}
+
+    {% set businessAddressActions = {
+      items: [
+        {
+          href: businessAddress.changeLink,
+          text: businessAddress.action,
+          visuallyHiddenText: "Business address",
+          classes: "govuk-link--no-visited-state"
+        }
+      ]
+    } %}
+
+    {% set businessTelephoneActions = {
+      items: [
+        {
+          href: businessTelephone.changeLink,
+          text: businessTelephone.action,
+          visuallyHiddenText: "Business telephone numbers",
+          classes: "govuk-link--no-visited-state"
+        }
+      ]
+    } %}
+
+    {% set businessEmailActions = {
+      items: [
+        {
+          href: businessEmail.changeLink,
+          text: businessEmail.action,
+          visuallyHiddenText: "Business email address",
+          classes: "govuk-link--no-visited-state"
+        }
+      ]
+    } %}
+
+    {{ govukSummaryList({
+      rows: [
+        {
+          key: { text: "Business name" },
+          value: { html: displayBusinessName },
+          actions: businessNameActions
+        },
+        {
+          key: { text: "Business address" },
+          value: { html: formattedAddress },
+          actions: businessAddressActions
+        },
+        {
+          key: { text: "Business phone numbers" },
+          value: { html: displayBusinessTelephone },
+          actions: businessTelephoneActions
+        },
+        {
+          key: { text: "Business email address" },
+          value: { html: displayBusinessEmail },
+          actions: businessEmailActions
+        }
+      ]
+    }) }}
+
+    <h2 class="govuk-heading-m">
+      Reference numbers
+    </h2>
+
+    {% set vatNumberActions = {
+      items: [
+        {
+          href: vatNumber.changeLink,
+          text: vatNumber.action,
+          visuallyHiddenText: "VAT registration number",
+          classes: "govuk-link--no-visited-state"
+        }
+      ]
+    } %}
+
+    {% set referenceRows = [
+      {
+        key: { text: "Single business identifier (SBI)" },
+        value: { text: sbi },
+        actions: { items: [] }
+      },
+      {
+        key: { text: "VAT registration number" },
+        value: { html: displayVatNumber },
+        actions: vatNumberActions
+      }
+    ] %}
+
+    {% if tradeNumber and tradeNumber | length %}
+      {% set _ = referenceRows.push({
+          key: { text: "Trader number" },
+          value: { html: tradeNumber }
+        })
+      %}
+    {% endif %}
+
+    {% if vendorRegistrationNumber and vendorRegistrationNumber | length %}
+      {% set _ = referenceRows.push({
+          key: { text: "Vendor registration number" },
+          value: { html: vendorRegistrationNumber }
+        })
+      %}
+    {% endif %}
+
+    {% if countyParishHoldingNumbers and countyParishHoldingNumbers | length %}
+      {% set _ = referenceRows.push({
+          key: { text: countyParishHoldingNumbersText },
+          value: { html: formattedCph }
+        })
+      %}
+    {% endif %}
+
+    {{ govukSummaryList({ rows: referenceRows }) }}
+
+    <h2 class="govuk-heading-m">
+      Additional details
+    </h2>
+
+    {% set businessLegalStatusDisplay %}
+      {% if businessLegalStatus.value === 'Not added' %}
+        <span class="govuk-hint display-inline">{{ businessLegalStatus.value }}</span>
+      {% else %}
+        <span>{{ businessLegalStatus.value }}</span>
+      {% endif %}
+    {% endset %}
+
+    {% set businessTypeDisplay %}
+      {% if businessType.value === 'Not added' %}
+        <span class="govuk-hint display-inline">{{ businessType.value }}</span>
+      {% else %}
+        <span>{{ businessType.value }}</span>
+      {% endif %}
+    {% endset %}
+
+    {% set businessLegalStatusActions = {
+      items: [
+        {
+          href: businessLegalStatus.changeLink,
+          text: businessLegalStatus.action,
+          visuallyHiddenText: "Business legal status",
+          classes: "govuk-link--no-visited-state"
+        }
+      ]
+    } %}
+
+    {% set businessTypeActions = {
+      items: [
+        {
+          href: businessType.changeLink,
+          text: businessType.action,
+          visuallyHiddenText: "Business type",
+          classes: "govuk-link--no-visited-state"
+        }
+      ]
+    } %}
+
+    {{ govukSummaryList({
+      rows: [
+        {
+          key: { text: "Business legal status" },
+          value: { html: businessLegalStatusDisplay },
+          actions: businessLegalStatusActions
+        },
+        {
+          key: { text: "Business type" },
+          value: { html: businessTypeDisplay },
+          actions: businessTypeActions
+        }
+      ]
+    }) }}
+
+  </div>
+</div>
+{% endblock %}

--- a/src/views/overview/business-overview.njk
+++ b/src/views/overview/business-overview.njk
@@ -19,7 +19,7 @@
 
       <h2 class="govuk-heading-m govuk-!-margin-top-5">Business details</h2>
       <p class="govuk-body">
-        <a href="#" class="govuk-link govuk-link--no-visited-state">View and update business details</a>
+        <a href="/business/{{ sbi }}/details" class="govuk-link govuk-link--no-visited-state">View and update business details</a>
       </p>
     </div>
   </div>

--- a/src/views/overview/business-overview.njk
+++ b/src/views/overview/business-overview.njk
@@ -19,7 +19,7 @@
 
       <h2 class="govuk-heading-m govuk-!-margin-top-5">Business details</h2>
       <p class="govuk-body">
-        <a href="/business/{{ sbi }}/details" class="govuk-link govuk-link--no-visited-state">View and update business details</a>
+        <a href="{{ businessDetailsLink }}" class="govuk-link govuk-link--no-visited-state">View and update business details</a>
       </p>
     </div>
   </div>

--- a/test/integration/narrow/routes/business/business-details-routes.test.js
+++ b/test/integration/narrow/routes/business/business-details-routes.test.js
@@ -1,0 +1,75 @@
+import { constants } from 'node:http2'
+import { vi, beforeAll, afterAll, describe, test, expect } from 'vitest'
+import { SCOPE } from '../../../../../src/constants/scope/business-details.js'
+import '../../../../mocks/setup-server-mocks.js'
+
+const { HTTP_STATUS_OK, HTTP_STATUS_FOUND } = constants
+
+vi.mock('../../../../../src/services/business/fetch-business-details-service.js', () => ({
+  fetchBusinessDetailsService: vi.fn()
+}))
+
+const { fetchBusinessDetailsService } = await import('../../../../../src/services/business/fetch-business-details-service.js')
+const { createServer } = await import('../../../../../src/server.js')
+
+describe('business details route', () => {
+  const sbi = '106705779'
+  const path = `/business/${sbi}/details`
+  let server
+
+  beforeAll(async () => {
+    vi.clearAllMocks()
+
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    if (server) {
+      await server.stop()
+    }
+  })
+
+  describe('GET /business/{sbi}/details', () => {
+    test('returns 200 and renders the business details view when authenticated', async () => {
+      fetchBusinessDetailsService.mockResolvedValue({
+        info: {
+          sbi,
+          businessName: 'Herberts Lawn Mowing',
+          vat: null,
+          traderNumber: null,
+          vendorNumber: null,
+          legalStatus: 'Sole Proprietorship',
+          type: 'Not Specified',
+          countyParishHoldingNumbers: []
+        },
+        address: { lookup: {}, manual: {}, postcode: null, country: null },
+        contact: { email: null, landline: null, mobile: null }
+      })
+
+      const response = await server.inject({
+        url: path,
+        auth: {
+          strategy: 'session',
+          credentials: {
+            sessionId: 'session-id',
+            scope: SCOPE
+          }
+        }
+      })
+
+      expect(response.statusCode).toBe(HTTP_STATUS_OK)
+      expect(response.request.response.source.template).toBe('business/business-details')
+    })
+
+    test('redirects to /auth/sign-in when not authenticated', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: path
+      })
+
+      expect(response.statusCode).toBe(HTTP_STATUS_FOUND)
+      expect(response.headers.location).toBe(`/auth/sign-in?redirect=${path}`)
+    })
+  })
+})

--- a/test/unit/mappers/business-details-mapper.test.js
+++ b/test/unit/mappers/business-details-mapper.test.js
@@ -1,0 +1,104 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach } from 'vitest'
+
+// Thing under test
+import { mapBusinessDetails } from '../../../src/mappers/business-details-mapper.js'
+
+describe('mapBusinessDetails', () => {
+  let rawData
+
+  beforeEach(() => {
+    rawData = {
+      business: {
+        sbi: '106705779',
+        info: {
+          name: 'Herberts Lawn Mowing',
+          vat: 'GB123456789',
+          traderNumber: '123456',
+          vendorNumber: '654321',
+          legalStatus: { type: 'Sole Proprietorship' },
+          type: { type: 'Not Specified' },
+          address: {
+            buildingNumberRange: '7',
+            street: 'Test Street',
+            city: 'London',
+            postalCode: 'SW1A 1AA',
+            country: 'United Kingdom',
+            line1: null,
+            uprn: null
+          },
+          email: { address: 'test@example.com' },
+          phone: { landline: '01234567890', mobile: '07700900000' }
+        },
+        countyParishHoldings: [{ cphNumber: '12/123/1234' }]
+      }
+    }
+  })
+
+  test('maps all fields correctly', () => {
+    const result = mapBusinessDetails(rawData)
+
+    expect(result.info.sbi).toBe('106705779')
+    expect(result.info.businessName).toBe('Herberts Lawn Mowing')
+    expect(result.info.vat).toBe('GB123456789')
+    expect(result.info.traderNumber).toBe('123456')
+    expect(result.info.vendorNumber).toBe('654321')
+    expect(result.info.legalStatus).toBe('Sole Proprietorship')
+    expect(result.info.type).toBe('Not Specified')
+    expect(result.info.countyParishHoldingNumbers).toEqual([{ cphNumber: '12/123/1234' }])
+    expect(result.contact.email).toBe('test@example.com')
+    expect(result.contact.landline).toBe('01234567890')
+    expect(result.contact.mobile).toBe('07700900000')
+  })
+
+  test('maps address using the engine address mapper', () => {
+    const result = mapBusinessDetails(rawData)
+
+    expect(result.address).toBeDefined()
+  })
+
+  test('does not include a customer property', () => {
+    const result = mapBusinessDetails(rawData)
+
+    expect(result.customer).toBeUndefined()
+  })
+
+  describe('when optional fields are absent', () => {
+    beforeEach(() => {
+      rawData.business.info.vat = null
+      rawData.business.info.traderNumber = null
+      rawData.business.info.vendorNumber = null
+      rawData.business.info.legalStatus = null
+      rawData.business.info.type = null
+      rawData.business.info.email = null
+      rawData.business.info.phone = null
+      rawData.business.countyParishHoldings = null
+    })
+
+    test('maps null/absent optional fields defensively', () => {
+      const result = mapBusinessDetails(rawData)
+
+      expect(result.info.vat).toBeNull()
+      expect(result.info.traderNumber).toBeNull()
+      expect(result.info.vendorNumber).toBeNull()
+      expect(result.info.legalStatus).toBeNull()
+      expect(result.info.type).toBeNull()
+      expect(result.info.countyParishHoldingNumbers).toEqual([])
+      expect(result.contact.email).toBeNull()
+      expect(result.contact.landline).toBeNull()
+      expect(result.contact.mobile).toBeNull()
+    })
+  })
+
+  describe('when the business name is missing', () => {
+    beforeEach(() => {
+      rawData.business.info.name = null
+    })
+
+    test('maps businessName as null', () => {
+      const result = mapBusinessDetails(rawData)
+
+      expect(result.info.businessName).toBeNull()
+    })
+  })
+})

--- a/test/unit/presenters/base-presenter.test.js
+++ b/test/unit/presenters/base-presenter.test.js
@@ -2,7 +2,7 @@
 import { describe, test, expect, beforeEach } from 'vitest'
 
 // Thing under test
-import { formatAddressLines } from '../../../src/presenters/base-presenter.js'
+import { formatAddressLines, formatDisplayAddress } from '../../../src/presenters/base-presenter.js'
 
 describe('basePresenter', () => {
   describe('#formatAddressLines', () => {
@@ -65,6 +65,33 @@ describe('basePresenter', () => {
         expect(result).toEqual({
           addressLines: 'Flat 1, The Farm House, 12 Farm Lane, Rural Area, West Fields, Exeter, Devon, England',
           postcode: 'EX1 1AA'
+        })
+      })
+
+      describe('#formatDisplayAddress', () => {
+        test('returns an array that includes postcode for lookup addresses', () => {
+          const address = {
+            lookup: {
+              buildingNumberRange: '10',
+              street: 'Main Street',
+              uprn: '300000000001'
+            },
+            manual: {},
+            city: 'Bristol',
+            postcode: 'BS1 1AA',
+            country: 'England'
+          }
+
+          expect(formatDisplayAddress(address)).toEqual([
+            '10 Main Street',
+            'Bristol',
+            'England',
+            'BS1 1AA'
+          ])
+        })
+
+        test('returns an empty array when address is absent', () => {
+          expect(formatDisplayAddress(null)).toEqual([])
         })
       })
     })

--- a/test/unit/presenters/base-presenter.test.js
+++ b/test/unit/presenters/base-presenter.test.js
@@ -2,7 +2,7 @@
 import { describe, test, expect, beforeEach } from 'vitest'
 
 // Thing under test
-import { formatAddressLines, formatDisplayAddress } from '../../../src/presenters/base-presenter.js'
+import { formatAddressLines } from '../../../src/presenters/base-presenter.js'
 
 describe('basePresenter', () => {
   describe('#formatAddressLines', () => {
@@ -65,33 +65,6 @@ describe('basePresenter', () => {
         expect(result).toEqual({
           addressLines: 'Flat 1, The Farm House, 12 Farm Lane, Rural Area, West Fields, Exeter, Devon, England',
           postcode: 'EX1 1AA'
-        })
-      })
-
-      describe('#formatDisplayAddress', () => {
-        test('returns an array that includes postcode for lookup addresses', () => {
-          const address = {
-            lookup: {
-              buildingNumberRange: '10',
-              street: 'Main Street',
-              uprn: '300000000001'
-            },
-            manual: {},
-            city: 'Bristol',
-            postcode: 'BS1 1AA',
-            country: 'England'
-          }
-
-          expect(formatDisplayAddress(address)).toEqual([
-            '10 Main Street',
-            'Bristol',
-            'England',
-            'BS1 1AA'
-          ])
-        })
-
-        test('returns an empty array when address is absent', () => {
-          expect(formatDisplayAddress(null)).toEqual([])
         })
       })
     })

--- a/test/unit/presenters/business/business-details-presenter.test.js
+++ b/test/unit/presenters/business/business-details-presenter.test.js
@@ -39,7 +39,7 @@ describe('businessDetailsPresenter', () => {
   test('returns correct pageTitle', () => {
     const result = businessDetailsPresenter(data, sbi)
 
-    expect(result.pageTitle).toBe('View business details')
+    expect(result.pageTitle).toBe('View and update your business details')
   })
 
   test('returns the sbi', () => {

--- a/test/unit/presenters/business/business-details-presenter.test.js
+++ b/test/unit/presenters/business/business-details-presenter.test.js
@@ -48,10 +48,20 @@ describe('businessDetailsPresenter', () => {
     expect(result.sbi).toBe(sbi)
   })
 
-  test('returns a back link pointing to the business overview page', () => {
+  test('returns breadcrumbs for search results and the business overview', () => {
     const result = businessDetailsPresenter(data, sbi)
 
-    expect(result.backLink).toEqual({ backLink: true, href: `/business-overview/${sbi}` })
+    expect(result.breadcrumbs).toEqual([
+      { text: 'Search results', href: `/search-sbi?sbi=${sbi}` },
+      { text: `Herberts Lawn Mowing (SBI: ${sbi})`, href: `/business/${sbi}` }
+    ])
+  })
+
+  test('falls back to just the SBI in the overview breadcrumb when the business name is absent', () => {
+    data.info.businessName = null
+    const result = businessDetailsPresenter(data, sbi)
+
+    expect(result.breadcrumbs[1]).toEqual({ text: `SBI: ${sbi}`, href: `/business/${sbi}` })
   })
 
   describe('businessName', () => {

--- a/test/unit/presenters/business/business-details-presenter.test.js
+++ b/test/unit/presenters/business/business-details-presenter.test.js
@@ -1,0 +1,242 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach } from 'vitest'
+
+// Thing under test
+import { businessDetailsPresenter } from '../../../../src/presenters/business/business-details-presenter.js'
+
+describe('businessDetailsPresenter', () => {
+  let data
+  let sbi
+
+  beforeEach(() => {
+    sbi = '106705779'
+
+    data = {
+      info: {
+        sbi,
+        businessName: 'Herberts Lawn Mowing',
+        vat: 'GB123456789',
+        traderNumber: '123456',
+        vendorNumber: '654321',
+        legalStatus: 'Sole Proprietorship',
+        type: 'Not Specified',
+        countyParishHoldingNumbers: [{ cphNumber: '12/123/1234' }]
+      },
+      address: {
+        lookup: { uprn: '123', buildingNumberRange: '7', street: 'Test St', city: 'London', county: 'Surrey' },
+        manual: {},
+        postcode: 'SW1A 1AA',
+        country: 'United Kingdom'
+      },
+      contact: {
+        email: 'test@example.com',
+        landline: '01234567890',
+        mobile: '07700900000'
+      }
+    }
+  })
+
+  test('returns correct pageTitle', () => {
+    const result = businessDetailsPresenter(data, sbi)
+
+    expect(result.pageTitle).toBe('View business details')
+  })
+
+  test('returns the sbi', () => {
+    const result = businessDetailsPresenter(data, sbi)
+
+    expect(result.sbi).toBe(sbi)
+  })
+
+  test('returns a back link pointing to the business overview page', () => {
+    const result = businessDetailsPresenter(data, sbi)
+
+    expect(result.backLink).toEqual({ backLink: true, href: `/business-overview/${sbi}` })
+  })
+
+  describe('businessName', () => {
+    test('returns the business name value and "Change" action when populated', () => {
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.businessName.value).toBe('Herberts Lawn Mowing')
+      expect(result.businessName.action).toBe('Change')
+      expect(result.businessName.changeLink).toBe('#')
+    })
+
+    test('returns "Not added" and "Add" action when business name is absent', () => {
+      data.info.businessName = null
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.businessName.value).toBe('Not added')
+      expect(result.businessName.action).toBe('Add')
+    })
+  })
+
+  describe('businessAddress', () => {
+    test('returns an array of address lines and "Change" action when address is present', () => {
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(Array.isArray(result.businessAddress.value)).toBe(true)
+      expect(result.businessAddress.action).toBe('Change')
+      expect(result.businessAddress.changeLink).toBe('#')
+    })
+
+    test('returns "Not added" and "Add" action when address has no content', () => {
+      data.address = { lookup: {}, manual: {}, postcode: null, country: null }
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.businessAddress.value).toBe('Not added')
+      expect(result.businessAddress.action).toBe('Add')
+    })
+  })
+
+  describe('businessTelephone', () => {
+    test('returns telephone and mobile values and "Change" action when populated', () => {
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.businessTelephone.telephone).toBe('01234567890')
+      expect(result.businessTelephone.mobile).toBe('07700900000')
+      expect(result.businessTelephone.action).toBe('Change')
+      expect(result.businessTelephone.changeLink).toBe('#')
+    })
+
+    test('returns "Not added" placeholders and "Add" action when both are absent', () => {
+      data.contact.landline = null
+      data.contact.mobile = null
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.businessTelephone.telephone).toBe('Not added')
+      expect(result.businessTelephone.mobile).toBe('Not added')
+      expect(result.businessTelephone.action).toBe('Add')
+    })
+  })
+
+  describe('businessEmail', () => {
+    test('returns email value and "Change" action when populated', () => {
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.businessEmail.value).toBe('test@example.com')
+      expect(result.businessEmail.action).toBe('Change')
+      expect(result.businessEmail.changeLink).toBe('#')
+    })
+
+    test('returns "Not added" and "Add" action when email is absent', () => {
+      data.contact.email = null
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.businessEmail.value).toBe('Not added')
+      expect(result.businessEmail.action).toBe('Add')
+    })
+  })
+
+  describe('vatNumber', () => {
+    test('returns the VAT number value and "Change" action when populated', () => {
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.vatNumber.value).toBe('GB123456789')
+      expect(result.vatNumber.action).toBe('Change')
+      expect(result.vatNumber.changeLink).toBe('#')
+    })
+
+    test('returns "No number added" and "Add" action when VAT is absent', () => {
+      data.info.vat = null
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.vatNumber.value).toBe('No number added')
+      expect(result.vatNumber.action).toBe('Add')
+    })
+  })
+
+  describe('reference numbers', () => {
+    test('returns tradeNumber when present', () => {
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.tradeNumber).toBe('123456')
+    })
+
+    test('returns null tradeNumber when absent', () => {
+      data.info.traderNumber = null
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.tradeNumber).toBeNull()
+    })
+
+    test('returns vendorRegistrationNumber when present', () => {
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.vendorRegistrationNumber).toBe('654321')
+    })
+
+    test('returns null vendorRegistrationNumber when absent', () => {
+      data.info.vendorNumber = null
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.vendorRegistrationNumber).toBeNull()
+    })
+  })
+
+  describe('countyParishHoldingNumbers', () => {
+    test('returns an array of CPH number strings', () => {
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.countyParishHoldingNumbers).toEqual(['12/123/1234'])
+    })
+
+    test('uses singular text when there is one CPH number', () => {
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.countyParishHoldingNumbersText).toBe('County Parish Holding (CPH) number')
+    })
+
+    test('uses plural text when there are multiple CPH numbers', () => {
+      data.info.countyParishHoldingNumbers = [{ cphNumber: '12/123/1234' }, { cphNumber: '12/123/5678' }]
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.countyParishHoldingNumbersText).toBe('County Parish Holding (CPH) numbers')
+      expect(result.countyParishHoldingNumbers).toEqual(['12/123/1234', '12/123/5678'])
+    })
+
+    test('returns an empty array when CPH data is absent', () => {
+      data.info.countyParishHoldingNumbers = []
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.countyParishHoldingNumbers).toEqual([])
+    })
+  })
+
+  describe('businessLegalStatus', () => {
+    test('returns the legal status value and "Change" action when populated', () => {
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.businessLegalStatus.value).toBe('Sole Proprietorship')
+      expect(result.businessLegalStatus.action).toBe('Change')
+      expect(result.businessLegalStatus.changeLink).toBe('#')
+    })
+
+    test('returns "Not added" and "Add" action when legal status is absent', () => {
+      data.info.legalStatus = null
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.businessLegalStatus.value).toBe('Not added')
+      expect(result.businessLegalStatus.action).toBe('Add')
+    })
+  })
+
+  describe('businessType', () => {
+    test('returns the business type value and "Change" action when populated', () => {
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.businessType.value).toBe('Not Specified')
+      expect(result.businessType.action).toBe('Change')
+      expect(result.businessType.changeLink).toBe('#')
+    })
+
+    test('returns "Not added" and "Add" action when business type is absent', () => {
+      data.info.type = null
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.businessType.value).toBe('Not added')
+      expect(result.businessType.action).toBe('Add')
+    })
+  })
+})

--- a/test/unit/presenters/overview/business-overview-presenter.test.js
+++ b/test/unit/presenters/overview/business-overview-presenter.test.js
@@ -46,8 +46,8 @@ describe('businessOverviewPresenter', () => {
         },
         breadcrumbs: [
           {
-            text: 'Search for another business',
-            href: '/search-sbi'
+            text: 'Search results',
+            href: '/search-sbi?sbi=106705779'
           }
         ]
       })
@@ -161,13 +161,13 @@ describe('businessOverviewPresenter', () => {
   })
 
   describe('the "breadcrumbs" property', () => {
-    test('it should always return the static search results breadcrumb', () => {
+    test('it should always return the search results breadcrumb with the SBI as a query param', () => {
       const result = businessOverviewPresenter(data, page)
 
       expect(result.breadcrumbs).toEqual([
         {
-          text: 'Search for another business',
-          href: '/search-sbi'
+          text: 'Search results',
+          href: '/search-sbi?sbi=106705779'
         }
       ])
     })

--- a/test/unit/presenters/overview/business-overview-presenter.test.js
+++ b/test/unit/presenters/overview/business-overview-presenter.test.js
@@ -30,6 +30,7 @@ describe('businessOverviewPresenter', () => {
         pageTitle: 'Business overview',
         sbi: '106705779',
         businessName: 'Herberts Lawn Mowing',
+        businessDetailsLink: '/business/106705779/details',
         hasCustomers: true,
         customers: [
           { fullName: 'Alice Smith', crn: '1100000001' },
@@ -156,6 +157,26 @@ describe('businessOverviewPresenter', () => {
         const result = businessOverviewPresenter(data, page)
 
         expect(result.customers[0]).toEqual({ fullName: '', crn: '' })
+      })
+    })
+  })
+
+  describe('the "businessDetailsLink" property', () => {
+    test('it should return a link to the business details page using the SBI', () => {
+      const result = businessOverviewPresenter(data, page)
+
+      expect(result.businessDetailsLink).toEqual('/business/106705779/details')
+    })
+
+    describe('when the sbi property is missing', () => {
+      beforeEach(() => {
+        delete data.sbi
+      })
+
+      test('it should return a link with undefined in the path', () => {
+        const result = businessOverviewPresenter(data, page)
+
+        expect(result.businessDetailsLink).toEqual('/business/undefined/details')
       })
     })
   })

--- a/test/unit/routes/business/business-details-routes.test.js
+++ b/test/unit/routes/business/business-details-routes.test.js
@@ -47,7 +47,7 @@ describe('business details routes', () => {
 
     describe('when sbi is valid and service returns data', () => {
       const businessDetails = { info: { businessName: 'Herberts Lawn Mowing' } }
-      const pageData = { pageTitle: 'View business details' }
+      const pageData = { pageTitle: 'View and update your business details' }
 
       beforeEach(() => {
         fetchBusinessDetailsService.mockResolvedValue(businessDetails)

--- a/test/unit/routes/business/business-details-routes.test.js
+++ b/test/unit/routes/business/business-details-routes.test.js
@@ -1,0 +1,103 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+// Things we need to mock
+import { fetchBusinessDetailsService } from '../../../../src/services/business/fetch-business-details-service.js'
+import { businessDetailsPresenter } from '../../../../src/presenters/business/business-details-presenter.js'
+
+// Thing under test
+import { businessDetailsRoutes } from '../../../../src/routes/business/business-details-routes.js'
+
+const [getBusinessDetails] = businessDetailsRoutes
+
+// Mocks
+vi.mock('../../../../src/services/business/fetch-business-details-service.js', () => ({
+  fetchBusinessDetailsService: vi.fn()
+}))
+
+vi.mock('../../../../src/presenters/business/business-details-presenter.js', () => ({
+  businessDetailsPresenter: vi.fn()
+}))
+
+describe('business details routes', () => {
+  let request
+  let h
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    request = {
+      params: { sbi: '106705779' },
+      auth: {
+        credentials: { email: 'test.user@defra.gov.uk' }
+      }
+    }
+
+    h = {
+      view: vi.fn(),
+      redirect: vi.fn().mockReturnValue({ takeover: vi.fn().mockReturnThis() })
+    }
+  })
+
+  describe('GET /business/{sbi}/details', () => {
+    test('should have the correct method and path configured', () => {
+      expect(getBusinessDetails.method).toBe('GET')
+      expect(getBusinessDetails.path).toBe('/business/{sbi}/details')
+    })
+
+    describe('when sbi is valid and service returns data', () => {
+      const businessDetails = { info: { businessName: 'Herberts Lawn Mowing' } }
+      const pageData = { pageTitle: 'View business details' }
+
+      beforeEach(() => {
+        fetchBusinessDetailsService.mockResolvedValue(businessDetails)
+        businessDetailsPresenter.mockReturnValue(pageData)
+      })
+
+      test('fetches details, presents them and renders the business details page', async () => {
+        await getBusinessDetails.handler(request, h)
+
+        expect(fetchBusinessDetailsService).toHaveBeenCalledWith('106705779', 'test.user@defra.gov.uk')
+        expect(businessDetailsPresenter).toHaveBeenCalledWith(businessDetails, '106705779')
+        expect(h.view).toHaveBeenCalledWith('business/business-details', pageData)
+      })
+    })
+
+    describe('when auth credentials have no email', () => {
+      beforeEach(() => {
+        request.auth = { credentials: undefined }
+        fetchBusinessDetailsService.mockResolvedValue({})
+        businessDetailsPresenter.mockReturnValue({})
+      })
+
+      test('passes undefined email to the service and still renders the page', async () => {
+        await getBusinessDetails.handler(request, h)
+
+        expect(fetchBusinessDetailsService).toHaveBeenCalledWith('106705779', undefined)
+      })
+    })
+
+    describe('when the sbi fails schema validation', () => {
+      beforeEach(() => {
+        request.params.sbi = 'not-a-valid-sbi'
+      })
+
+      test('redirects to /search-sbi', async () => {
+        await getBusinessDetails.handler(request, h)
+
+        expect(h.redirect).toHaveBeenCalledWith('/search-sbi')
+        expect(fetchBusinessDetailsService).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when fetchBusinessDetailsService throws', () => {
+      beforeEach(() => {
+        fetchBusinessDetailsService.mockRejectedValue(new Error('Business not found'))
+      })
+
+      test('throws the error from the service', async () => {
+        await expect(getBusinessDetails.handler(request, h)).rejects.toThrow('Business not found')
+      })
+    })
+  })
+})

--- a/test/unit/routes/search/search-sbi-routes.test.js
+++ b/test/unit/routes/search/search-sbi-routes.test.js
@@ -63,6 +63,7 @@ describe('search sbi routes', () => {
           email: 'test@example.com'
         }
       },
+      query: {},
       payload: {
         sbi: '106705779'
       }
@@ -93,6 +94,41 @@ describe('search sbi routes', () => {
         expect(fetchSbiSearchDetailsService).not.toHaveBeenCalled()
         expect(searchSbiPresenter).not.toHaveBeenCalled()
         expect(request.yar.clear).not.toHaveBeenCalled()
+      })
+
+      describe('when a valid SBI is provided as a query param', () => {
+        const details = { info: { businessName: 'Herberts Lawn Mowing' } }
+        const pageData = { resultText: '1 result for "106705779"' }
+
+        beforeEach(() => {
+          request.query = { sbi: '106705779' }
+          mockValidate.mockReturnValue({ value: { sbi: '106705779' } })
+          fetchSbiSearchDetailsService.mockResolvedValue(details)
+          searchSbiPresenter.mockReturnValue(pageData)
+        })
+
+        test('it fetches details, presents them and clears session state', async () => {
+          await getSearchSbi.handler(request, h)
+
+          expect(fetchSbiSearchDetailsService).toHaveBeenCalledWith('106705779', 'test@example.com')
+          expect(searchSbiPresenter).toHaveBeenCalledWith(details, '106705779')
+          expect(request.yar.clear).toHaveBeenCalledWith('searchSbi')
+          expect(h.view).toHaveBeenCalledWith('search/search-sbi', pageData)
+        })
+      })
+
+      describe('when an invalid SBI is provided as a query param', () => {
+        beforeEach(() => {
+          request.query = { sbi: 'not-an-sbi' }
+          mockValidate.mockReturnValue({ error: { details: [] } })
+        })
+
+        test('it renders the search page with no page data', async () => {
+          await getSearchSbi.handler(request, h)
+
+          expect(h.view).toHaveBeenCalledWith('search/search-sbi')
+          expect(fetchSbiSearchDetailsService).not.toHaveBeenCalled()
+        })
       })
     })
 

--- a/test/unit/services/business/fetch-business-details-service.test.js
+++ b/test/unit/services/business/fetch-business-details-service.test.js
@@ -1,0 +1,108 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import Boom from '@hapi/boom'
+
+// Things we need to mock
+import { businessDetailsQuery } from '../../../../src/dal/queries/business-details.js'
+
+// Mock dependencies
+const mockMapBusinessDetails = vi.fn()
+const mockDalConnector = { query: vi.fn() }
+
+vi.mock('../../../../src/dal/connector.js', () => ({
+  getDalConnector: vi.fn(() => mockDalConnector)
+}))
+
+vi.mock('../../../../src/mappers/business-details-mapper.js', () => ({
+  mapBusinessDetails: mockMapBusinessDetails
+}))
+
+// Thing under test
+const { fetchBusinessDetailsService } = await import('../../../../src/services/business/fetch-business-details-service.js')
+
+describe('fetchBusinessDetailsService', () => {
+  let sbi
+  let email
+  let dalData
+  let mappedData
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    sbi = '106705779'
+    email = 'test.user@defra.gov.uk'
+
+    dalData = {
+      business: {
+        sbi: '106705779',
+        info: {
+          name: 'Herberts Lawn Mowing',
+          vat: 'GB123456789',
+          traderNumber: '123456',
+          vendorNumber: '654321',
+          legalStatus: { type: 'Sole Proprietorship' },
+          type: { type: 'Not Specified' },
+          address: {},
+          email: { address: 'test@example.com' },
+          phone: { landline: '01234567890', mobile: null }
+        },
+        countyParishHoldings: []
+      }
+    }
+
+    mappedData = {
+      info: {
+        sbi: '106705779',
+        businessName: 'Herberts Lawn Mowing',
+        vat: 'GB123456789',
+        traderNumber: '123456',
+        vendorNumber: '654321',
+        legalStatus: 'Sole Proprietorship',
+        type: 'Not Specified',
+        countyParishHoldingNumbers: []
+      },
+      address: {},
+      contact: {
+        email: 'test@example.com',
+        landline: '01234567890',
+        mobile: null
+      }
+    }
+  })
+
+  describe('when DAL returns data', () => {
+    beforeEach(() => {
+      mockDalConnector.query.mockResolvedValue({ data: dalData })
+      mockMapBusinessDetails.mockReturnValue(mappedData)
+    })
+
+    test('should call DAL connector with businessDetailsQuery and sbi', async () => {
+      await fetchBusinessDetailsService(sbi, email)
+
+      expect(mockDalConnector.query).toHaveBeenCalledWith(
+        businessDetailsQuery,
+        { sbi },
+        email
+      )
+    })
+
+    test('should return mapped data', async () => {
+      const result = await fetchBusinessDetailsService(sbi, email)
+
+      expect(mockMapBusinessDetails).toHaveBeenCalledWith(dalData)
+      expect(result).toEqual(mappedData)
+    })
+  })
+
+  describe('when the DAL returns no data', () => {
+    beforeEach(() => {
+      mockDalConnector.query.mockResolvedValue({ data: null })
+    })
+
+    test('should throw Boom.notFound error', async () => {
+      await expect(fetchBusinessDetailsService(sbi, email)).rejects.toThrow(Boom.notFound('Business not found'))
+
+      expect(mockMapBusinessDetails).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
This PR adds the "View and update business details" page to the internal frontend service. 

- The business details page renders all business details with appropriate change/add links added (this are only placeholders that have a `href` value of `#`).
- Clicking "Search results" in breadcrumbs takes you back to the search result page injecting the provided SBI as the query param. 
- Clicking on the business name + SBI in the breadcrumbs takes you to the business page with the list of associated CRNs.
