### PR TITLE
FLS2-127: Fix Missing Organisation Name on Business Details Address

### DIFF
--- a/src/dal/queries/business-details-by-sbi.js
+++ b/src/dal/queries/business-details-by-sbi.js
@@ -7,6 +7,7 @@ export const businessDetailsBySbi = `
       traderNumber
       vendorNumber
       address {
+        pafOrganisationName
         buildingNumberRange
         buildingName
         flatName


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FLS2-127

## Summary

When a business address has an organisation name stored in `pafOrganisationName` (e.g. `UPPER CRUST`), it was silently dropped from the displayed address because the `businessDetailsBySbi` GraphQL query never requested the field.

The `mappers.address()` engine function maps `pafOrganisationName` into `lookup.pafOrganisationName`, and `formatDisplayAddress` emits it as the first address line — but only if the value is present. Because the field was absent from the query, the DAL never returned it, `mappers.address()` received `undefined`, and `.filter(Boolean)` silently dropped it from the rendered address.

This is the same root cause as the equivalent fix in `fcp-sfd-frontend`.

## Changes

- Add `pafOrganisationName` to the `address` selection set in `businessDetailsBySbi` in `src/dal/queries/business-details-by-sbi.js`