### PR TITLE
chore: bump @defra/fcp-sfd-frontend-engine to 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@defra/fcp-sfd-frontend-engine": "0.5.0",
+        "@defra/fcp-sfd-frontend-engine": "0.7.0",
         "@defra/hapi-tracing": "1.30.0",
         "@elastic/ecs-pino-format": "1.5.0",
         "@hapi/bell": "13.1.0",
@@ -492,9 +492,9 @@
       "license": "MIT"
     },
     "node_modules/@defra/fcp-sfd-frontend-engine": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.5.0.tgz",
-      "integrity": "sha512-oQKXvqYKijXv272WnpSVc4BrhnNZucHxHaLYvf1xRC+nHnor6GuElNBiI9Ul4iS4RSlsJKyShUlMG1AnAxvtvA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.7.0.tgz",
+      "integrity": "sha512-bLa/6U2A24LP/wcYNaGKdatfIRQo1BBOSlq+9p1tnLyatTEZMgUJm6aZfGyymvw1XoWbSLT/xwuwNvo+OedB8Q==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "joi": "18.2.1"
@@ -5354,6 +5354,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -10242,7 +10243,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10260,7 +10260,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10278,7 +10277,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10296,7 +10294,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10314,7 +10311,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10332,7 +10328,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10350,7 +10345,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10368,7 +10362,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "license": "OGL-UK-3.0",
   "dependencies": {
-    "@defra/fcp-sfd-frontend-engine": "0.5.0",
+    "@defra/fcp-sfd-frontend-engine": "0.7.0",
     "@defra/hapi-tracing": "1.30.0",
     "@elastic/ecs-pino-format": "1.5.0",
     "@hapi/bell": "13.1.0",


### PR DESCRIPTION
## Summary

Bumps `@defra/fcp-sfd-frontend-engine` from `0.5.0` to `0.7.0`.

## Changes

- `package.json` — engine dependency `0.5.0` → `0.7.0`
- `package-lock.json` — updated to match