### PR TITLE
FLS2-53: Add Personal Name Change Journey

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@defra/fcp-sfd-frontend-engine": "0.8.0",
+        "@defra/fcp-sfd-frontend-engine": "0.10.0",
         "@defra/hapi-tracing": "1.30.0",
         "@elastic/ecs-pino-format": "1.5.0",
         "@hapi/bell": "13.1.0",
@@ -491,12 +491,12 @@
       "license": "MIT"
     },
     "node_modules/@defra/fcp-sfd-frontend-engine": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.8.0.tgz",
-      "integrity": "sha512-pZQQ08tL+kjPEpgo4nKbdMA5AMFziEZIp+0paMZNBKb3EEDxUnbWLPsFirX/11vdsfTTUu+rCcx/U4yXcpR0KA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.10.0.tgz",
+      "integrity": "sha512-ewZLB6CryrTXtBQUSZB1rPPEIq4j1BtvfCkefkWODTOHyVFX32Sb2Gb/wczE7zZzgRFduCZnEUy0DTgkovhMNA==",
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "joi": "18.2.1"
+        "joi": "18.2.3"
       }
     },
     "node_modules/@defra/hapi-tracing": {
@@ -5342,6 +5342,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6779,9 +6780,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
-      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
+      "version": "18.2.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.3.tgz",
+      "integrity": "sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/address": "^5.1.1",
@@ -10278,7 +10279,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10296,7 +10296,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10314,7 +10313,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10332,7 +10330,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10350,7 +10347,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10368,7 +10364,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10386,7 +10381,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10404,7 +10398,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "license": "OGL-UK-3.0",
   "dependencies": {
-    "@defra/fcp-sfd-frontend-engine": "0.8.0",
+    "@defra/fcp-sfd-frontend-engine": "0.10.0",
     "@defra/hapi-tracing": "1.30.0",
     "@elastic/ecs-pino-format": "1.5.0",
     "@hapi/bell": "13.1.0",

--- a/src/presenters/personal-details-presenter.js
+++ b/src/presenters/personal-details-presenter.js
@@ -75,10 +75,10 @@ const getActionText = (value) => {
 const formatChangeLinks = (crn, hasValidPersonalDetails, sectionsNeedingUpdate = []) => {
   const CHANGE_LINKS = {
     name: `/customer/${crn}/account-name-change`,
-    address: '/account-address-change',
-    phone: '/account-phone-numbers-change',
-    email: '/account-email-change',
-    dob: '/account-date-of-birth-change'
+    address: `/customer/${crn}/account-address-change`,
+    phone: `/customer/${crn}/account-phone-numbers-change`,
+    email: `/customer/${crn}/account-email-change`,
+    dob: `/customer/${crn}/account-date-of-birth-change`
   }
 
   const personalDetailsInterrupterEnabled = config.get('featureToggle.personalDetailsInterrupterEnabled')

--- a/src/presenters/personal-details-presenter.js
+++ b/src/presenters/personal-details-presenter.js
@@ -8,7 +8,7 @@ import { presenters } from '@defra/fcp-sfd-frontend-engine'
 import { config } from '../config/index.js'
 
 const personalDetailsPresenter = (data, yar, hasValidPersonalDetails, sectionsNeedingUpdate) => {
-  const changeLinks = formatChangeLinks(hasValidPersonalDetails, sectionsNeedingUpdate)
+  const changeLinks = formatChangeLinks(data.crn, hasValidPersonalDetails, sectionsNeedingUpdate)
   const { action: dobAction, formattedDob } = formatDob(data.info.dateOfBirth.full)
 
   return {
@@ -72,9 +72,9 @@ const getActionText = (value) => {
  * - If only one section needs updating, its normal change link is used
  * - Otherwise, all links point to the personal details fix journey
  */
-const formatChangeLinks = (hasValidPersonalDetails, sectionsNeedingUpdate = []) => {
+const formatChangeLinks = (crn, hasValidPersonalDetails, sectionsNeedingUpdate = []) => {
   const CHANGE_LINKS = {
-    name: '/account-name-change',
+    name: `/customer/${crn}/account-name-change`,
     address: '/account-address-change',
     phone: '/account-phone-numbers-change',
     email: '/account-email-change',

--- a/src/presenters/personal/personal-name-change-presenter.js
+++ b/src/presenters/personal/personal-name-change-presenter.js
@@ -5,7 +5,7 @@
 
 const personalNameChangePresenter = (data, payload, crn) => {
   return {
-    backLink: { href: `/customer/${crn}/details` },
+    backLink: { href: crn ? `/customer/${crn}/details` : '/search-crn' },
     pageTitle: 'What is your full name?',
     metaDescription: 'Update the full name for your personal account.',
     userName: data.info.userName ?? null,

--- a/src/presenters/personal/personal-name-change-presenter.js
+++ b/src/presenters/personal/personal-name-change-presenter.js
@@ -1,5 +1,5 @@
 /*
- * Formats data ready for presenting in the personal name change page
+ * Formats data ready for presenting in the `/customer/{CRN}/details/account-name-change` page
  * @module personalNameChangePresenter
  */
 

--- a/src/presenters/personal/personal-name-change-presenter.js
+++ b/src/presenters/personal/personal-name-change-presenter.js
@@ -1,0 +1,20 @@
+/*
+ * Formats data ready for presenting in the personal name change page
+ * @module personalNameChangePresenter
+ */
+
+const personalNameChangePresenter = (data, payload, crn) => {
+  return {
+    backLink: { href: `/customer/${crn}/details` },
+    pageTitle: 'What is your full name?',
+    metaDescription: 'Update the full name for your personal account.',
+    userName: data.info.userName ?? null,
+    first: payload?.first ?? data.changePersonalName?.first ?? data.info.fullName.first,
+    middle: payload?.middle ?? data.changePersonalName?.middle ?? data.info.fullName.middle,
+    last: payload?.last ?? data.changePersonalName?.last ?? data.info.fullName.last
+  }
+}
+
+export {
+  personalNameChangePresenter
+}

--- a/src/presenters/personal/personal-name-check-presenter.js
+++ b/src/presenters/personal/personal-name-check-presenter.js
@@ -1,5 +1,5 @@
 /**
- * Formats data ready for presenting in the personal name check page
+ * Formats data ready for presenting in the `/customer/{CRN}/details/account-name-check` page
  * @module personalNameCheckPresenter
  */
 

--- a/src/presenters/personal/personal-name-check-presenter.js
+++ b/src/presenters/personal/personal-name-check-presenter.js
@@ -1,0 +1,21 @@
+/**
+ * Formats data ready for presenting in the personal name check page
+ * @module personalNameCheckPresenter
+ */
+
+import { utils } from '@defra/fcp-sfd-frontend-engine'
+
+const personalNameCheckPresenter = (personalDetails, crn) => {
+  return {
+    backLink: { href: `/customer/${crn}/account-name-change` },
+    changeLink: `/customer/${crn}/account-name-change`,
+    pageTitle: 'Check your name is correct before submitting',
+    metaDescription: 'Check the full name for your personal account is correct.',
+    userName: personalDetails.info.userName ?? null,
+    fullName: utils.formatFullName(personalDetails.changePersonalName ?? personalDetails.info.fullName)
+  }
+}
+
+export {
+  personalNameCheckPresenter
+}

--- a/src/routes/customer/customer-details-routes.js
+++ b/src/routes/customer/customer-details-routes.js
@@ -17,6 +17,8 @@ const getCustomerDetails = {
       return h.redirect('/search-crn')
     }
 
+    yar.clear('personalDetailsUpdate')
+
     const email = auth.credentials?.email
     const personalDetails = await fetchPersonalDetailsService(crn, email)
     const { hasValidPersonalDetails, sectionsNeedingUpdate } = validatePersonalDetailsService(personalDetails)

--- a/src/routes/customer/personal-name-change-routes.js
+++ b/src/routes/customer/personal-name-change-routes.js
@@ -1,0 +1,61 @@
+import { schemas, utils, constants } from '@defra/fcp-sfd-frontend-engine'
+
+import { personalNameChangePresenter } from '../../presenters/personal/personal-name-change-presenter.js'
+import { fetchPersonalChangeService } from '../../services/personal/fetch-personal-change-service.js'
+import { setSessionData } from '../../utils/session/set-session-data.js'
+
+const getPersonalNameChange = {
+  method: 'GET',
+  path: '/customer/{crn}/account-name-change',
+  handler: async (request, h) => {
+    const { params, auth, yar } = request
+    const { crn } = params
+
+    const { error } = schemas.customer.crn.validate({ crn })
+
+    if (error) {
+      return h.redirect('/search-crn')
+    }
+
+    const email = auth.credentials?.email
+    const personalDetails = await fetchPersonalChangeService(yar, crn, email, 'changePersonalName')
+    const pageData = personalNameChangePresenter(personalDetails, undefined, crn)
+
+    return h.view('personal/personal-name-change', pageData)
+  }
+}
+
+const postPersonalNameChange = {
+  method: 'POST',
+  path: '/customer/{crn}/account-name-change',
+  options: {
+    validate: {
+      payload: schemas.personal.name,
+      options: { abortEarly: false },
+      failAction: async (request, h, err) => {
+        const { params, auth, yar, payload } = request
+        const { crn } = params
+
+        const email = auth.credentials?.email
+        const errors = utils.formatValidationErrors(err.details || [])
+        const personalDetails = await fetchPersonalChangeService(yar, crn, email, 'changePersonalName')
+        const pageData = personalNameChangePresenter(personalDetails, payload, crn)
+
+        return h.view('personal/personal-name-change', { ...pageData, errors }).code(constants.statusCodes.BAD_REQUEST).takeover()
+      }
+    },
+    handler: async (request, h) => {
+      const { params, yar, payload } = request
+      const { crn } = params
+
+      setSessionData(yar, 'personalDetailsUpdate', 'changePersonalName', payload)
+
+      return h.redirect(`/customer/${crn}/account-name-check`)
+    }
+  }
+}
+
+export const personalNameChangeRoutes = [
+  getPersonalNameChange,
+  postPersonalNameChange
+]

--- a/src/routes/customer/personal-name-check-routes.js
+++ b/src/routes/customer/personal-name-check-routes.js
@@ -1,0 +1,45 @@
+import { schemas } from '@defra/fcp-sfd-frontend-engine'
+
+import { personalNameCheckPresenter } from '../../presenters/personal/personal-name-check-presenter.js'
+import { fetchPersonalChangeService } from '../../services/personal/fetch-personal-change-service.js'
+import { updatePersonalNameChangeService } from '../../services/personal/update-personal-name-change-service.js'
+
+const getPersonalNameCheck = {
+  method: 'GET',
+  path: '/customer/{crn}/account-name-check',
+  handler: async (request, h) => {
+    const { params, auth, yar } = request
+    const { crn } = params
+
+    const { error } = schemas.customer.crn.validate({ crn })
+
+    if (error) {
+      return h.redirect('/search-crn')
+    }
+
+    const email = auth.credentials?.email
+    const personalDetails = await fetchPersonalChangeService(yar, crn, email, 'changePersonalName')
+    const pageData = personalNameCheckPresenter(personalDetails, crn)
+
+    return h.view('personal/personal-name-check', pageData)
+  }
+}
+
+const postPersonalNameCheck = {
+  method: 'POST',
+  path: '/customer/{crn}/account-name-check',
+  handler: async (request, h) => {
+    const { params, auth, yar } = request
+    const { crn } = params
+
+    const email = auth.credentials?.email
+    await updatePersonalNameChangeService(yar, crn, email)
+
+    return h.redirect(`/customer/${crn}/details`)
+  }
+}
+
+export const personalNameCheckRoutes = [
+  getPersonalNameCheck,
+  postPersonalNameCheck
+]

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -12,6 +12,8 @@ import { changeSearchCriteriaRoutes } from './search/change-search-criteria-rout
 import { customerOverviewRoutes } from './overview/customer-routes.js'
 import { businessOverviewRoutes } from './overview/business-routes.js'
 import { customerDetailsRoutes } from './customer/customer-details-routes.js'
+import { personalNameChangeRoutes } from './customer/personal-name-change-routes.js'
+import { personalNameCheckRoutes } from './customer/personal-name-check-routes.js'
 import { businessDetailsRoutes } from './business/business-details-routes.js'
 
 export const routes = [
@@ -29,5 +31,7 @@ export const routes = [
   ...customerOverviewRoutes,
   ...businessOverviewRoutes,
   ...customerDetailsRoutes,
+  ...personalNameChangeRoutes,
+  ...personalNameCheckRoutes,
   ...businessDetailsRoutes
 ]

--- a/src/services/personal/fetch-personal-change-service.js
+++ b/src/services/personal/fetch-personal-change-service.js
@@ -1,0 +1,33 @@
+import { fetchPersonalDetailsService } from '../fetch-personal-details-service.js'
+
+/**
+ * Fetches the latest personal details from the DAL and merges in a temporary change stored in the user's session
+ * for a specific field like changePersonalName.
+ *
+ * For example, if the user has typed a new name but hasn't saved it yet, this will return the fresh personal
+ * details with that new name included (changePersonalName).
+ *
+ * @param {object} yar - The hapi `request.yar` object
+ * @param {string} crn - The customer reference number of the customer being viewed
+ * @param {string} email - The internal user's email address (sent to the DAL in the request headers)
+ * @param {string|string[]} fields - The input field(s) the user has updated that we want to fetch (if exists)
+ */
+const fetchPersonalChangeService = async (yar, crn, email, fields) => {
+  const personalDetails = await fetchPersonalDetailsService(crn, email)
+  const sessionData = yar.get('personalDetailsUpdate') || {}
+
+  // Normalise to array
+  const fieldsToCheck = Array.isArray(fields) ? fields : [fields]
+
+  for (const field of fieldsToCheck) {
+    if (sessionData[field] !== undefined) {
+      personalDetails[field] = sessionData[field]
+    }
+  }
+
+  return personalDetails
+}
+
+export {
+  fetchPersonalChangeService
+}

--- a/src/services/personal/update-personal-name-change-service.js
+++ b/src/services/personal/update-personal-name-change-service.js
@@ -1,0 +1,43 @@
+/**
+ * Service to update a personal full name (first, last and middle)
+ *
+ * Fetches the pending personal name changes from the session
+ * Calls the DAL to persist the updated name fields using updateDalService
+ * Clears the cached personal details data from the session
+ * Displays a success flash notification to the user
+ *
+ * @module updatePersonalNameChangeService
+ */
+
+import { mutations } from '@defra/fcp-sfd-frontend-engine'
+
+import { fetchPersonalChangeService } from './fetch-personal-change-service.js'
+import { flashNotification } from '../../utils/notifications/flash-notification.js'
+import { updateDalService } from '../DAL/update-dal-service.js'
+
+const updatePersonalNameChangeService = async (yar, crn, email) => {
+  const personalDetails = await fetchPersonalChangeService(yar, crn, email, 'changePersonalName')
+
+  if (!personalDetails.changePersonalName) {
+    return
+  }
+
+  const variables = {
+    input: {
+      first: personalDetails.changePersonalName.first,
+      last: personalDetails.changePersonalName.last,
+      middle: personalDetails.changePersonalName.middle ?? null,
+      crn: personalDetails.crn
+    }
+  }
+
+  await updateDalService(mutations.updateCustomerName, variables, email)
+
+  yar.clear('personalDetailsUpdate')
+
+  flashNotification(yar, 'Success', 'You have updated your full name')
+}
+
+export {
+  updatePersonalNameChangeService
+}

--- a/src/utils/session/set-session-data.js
+++ b/src/utils/session/set-session-data.js
@@ -20,7 +20,7 @@
  * @returns {object} - The updated session data object
  */
 const setSessionData = (yar, key, value, data) => {
-  const sessionData = yar.get(key)
+  const sessionData = yar.get(key) || {}
 
   sessionData[value] = data
 

--- a/src/views/personal/personal-name-change.njk
+++ b/src/views/personal/personal-name-change.njk
@@ -1,0 +1,74 @@
+{% extends 'common/layout.njk' %}
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "common/navigation/back-sign-out-link.njk" import appBackSignOutLink with context %}
+
+{% block beforeContent %}
+  {{ appBackSignOutLink({ backLink: backLink, href: backLink.href }) }}
+{% endblock %}
+
+{% block content %}
+  {% if errors %}
+    {{ govukErrorSummary({
+        titleText: "There is a problem",
+        errorList: errors | toErrorList
+    }) }}
+  {% endif %}
+
+<div class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post" novalidate>
+        <input type="hidden" name="crumb" value="{{ crumb }}">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading">
+              {{ pageTitle }}
+            </h1>
+          </legend>
+
+          {{ govukInput({
+            label: {
+              text: "First name"
+            },
+            id: "first",
+            name: "first",
+            value: first,
+            errorMessage: errors.first and {
+              text: errors.first.text
+            }
+          }) }}
+
+          {{ govukInput({
+            label: {
+              text: "Middle names"
+            },
+            id: "middle",
+            name: "middle",
+            value: middle,
+            errorMessage: errors.middle and {
+              text: errors.middle.text
+            }
+          }) }}
+
+          {{ govukInput({
+            label: {
+              text: "Last name"
+            },
+            id: "last",
+            name: "last",
+            value: last,
+            errorMessage: errors.last and {
+              text: errors.last.text
+            }
+          }) }}
+        </fieldset>
+
+        {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/src/views/personal/personal-name-check.njk
+++ b/src/views/personal/personal-name-check.njk
@@ -1,0 +1,49 @@
+{% extends 'common/layout.njk' %}
+
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "common/navigation/back-sign-out-link.njk" import appBackSignOutLink with context %}
+
+{% block beforeContent %}
+  {{ appBackSignOutLink({ backLink: backLink, href: backLink.href }) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post" novalidate>
+        <input type="hidden" name="crumb" value="{{ crumb }}">
+        <h1 class="govuk-heading-l">
+          {{ pageTitle }}
+        </h1>
+
+        {{ govukSummaryList({
+          rows: [
+            {
+              key: {
+                text: "Full name"
+              },
+              value: {
+                text: fullName
+              },
+              actions: {
+                items: [
+                  {
+                    href: changeLink,
+                    text: "Change",
+                    visuallyHiddenText: "full name",
+                    classes: "govuk-link--no-visited-state"
+                  }
+                ]
+              }
+            }
+          ]
+        }) }}
+
+        {{ govukButton({ text: "Submit", preventDoubleClick: true }) }}
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/test/unit/presenters/personal-details-presenter.test.js
+++ b/test/unit/presenters/personal-details-presenter.test.js
@@ -73,7 +73,7 @@ describe('personalDetailsPresenter', () => {
             'United Kingdom'
           ],
           action: 'Change',
-          changeLink: '/account-address-change'
+          changeLink: `/customer/${data.crn}/account-address-change`
         },
         personalName: {
           fullName: 'John M Doe',
@@ -83,18 +83,18 @@ describe('personalDetailsPresenter', () => {
         dob: {
           fullDateOfBirth: '1 January 1990',
           action: 'Change',
-          changeLink: '/account-date-of-birth-change'
+          changeLink: `/customer/${data.crn}/account-date-of-birth-change`
         },
         personalTelephone: {
           telephone: data.contact.telephone,
           mobile: 'Not added',
           action: 'Change',
-          changeLink: '/account-phone-numbers-change'
+          changeLink: `/customer/${data.crn}/account-phone-numbers-change`
         },
         personalEmail: {
           email: data.contact.email,
           action: 'Change',
-          changeLink: '/account-email-change'
+          changeLink: `/customer/${data.crn}/account-email-change`
         }
       })
     })
@@ -386,10 +386,10 @@ describe('personalDetailsPresenter', () => {
         const result = personalDetailsPresenter(data, yar, hasValidPersonalDetails, sectionsNeedingUpdate)
 
         expect(result.personalName.changeLink).toBe(`/customer/${data.crn}/account-name-change`)
-        expect(result.personalAddress.changeLink).toBe('/account-address-change')
-        expect(result.personalTelephone.changeLink).toBe('/account-phone-numbers-change')
-        expect(result.personalEmail.changeLink).toBe('/account-email-change')
-        expect(result.dob.changeLink).toBe('/account-date-of-birth-change')
+        expect(result.personalAddress.changeLink).toBe(`/customer/${data.crn}/account-address-change`)
+        expect(result.personalTelephone.changeLink).toBe(`/customer/${data.crn}/account-phone-numbers-change`)
+        expect(result.personalEmail.changeLink).toBe(`/customer/${data.crn}/account-email-change`)
+        expect(result.dob.changeLink).toBe(`/customer/${data.crn}/account-date-of-birth-change`)
       })
     })
 
@@ -404,10 +404,10 @@ describe('personalDetailsPresenter', () => {
           const result = personalDetailsPresenter(data, yar, hasValidPersonalDetails, sectionsNeedingUpdate)
 
           expect(result.personalName.changeLink).toBe(`/customer/${data.crn}/account-name-change`)
-          expect(result.personalAddress.changeLink).toBe('/account-address-change')
-          expect(result.personalTelephone.changeLink).toBe('/account-phone-numbers-change')
-          expect(result.personalEmail.changeLink).toBe('/account-email-change')
-          expect(result.dob.changeLink).toBe('/account-date-of-birth-change')
+          expect(result.personalAddress.changeLink).toBe(`/customer/${data.crn}/account-address-change`)
+          expect(result.personalTelephone.changeLink).toBe(`/customer/${data.crn}/account-phone-numbers-change`)
+          expect(result.personalEmail.changeLink).toBe(`/customer/${data.crn}/account-email-change`)
+          expect(result.dob.changeLink).toBe(`/customer/${data.crn}/account-date-of-birth-change`)
         })
       })
 
@@ -438,7 +438,7 @@ describe('personalDetailsPresenter', () => {
           const result = personalDetailsPresenter(data, yar, hasValidPersonalDetails, sectionsNeedingUpdate)
 
           expect(result.personalName.changeLink).toBe('/personal-fix?source=name')
-          expect(result.personalAddress.changeLink).toBe('/account-address-change')
+          expect(result.personalAddress.changeLink).toBe(`/customer/${data.crn}/account-address-change`)
           expect(result.personalTelephone.changeLink).toBe('/personal-fix?source=phone')
           expect(result.personalEmail.changeLink).toBe('/personal-fix?source=email')
           expect(result.dob.changeLink).toBe('/personal-fix?source=dob')
@@ -456,7 +456,7 @@ describe('personalDetailsPresenter', () => {
 
           expect(result.personalName.changeLink).toBe('/personal-fix?source=name')
           expect(result.personalAddress.changeLink).toBe('/personal-fix?source=address')
-          expect(result.personalTelephone.changeLink).toBe('/account-phone-numbers-change')
+          expect(result.personalTelephone.changeLink).toBe(`/customer/${data.crn}/account-phone-numbers-change`)
           expect(result.personalEmail.changeLink).toBe('/personal-fix?source=email')
           expect(result.dob.changeLink).toBe('/personal-fix?source=dob')
         })
@@ -474,7 +474,7 @@ describe('personalDetailsPresenter', () => {
           expect(result.personalName.changeLink).toBe('/personal-fix?source=name')
           expect(result.personalAddress.changeLink).toBe('/personal-fix?source=address')
           expect(result.personalTelephone.changeLink).toBe('/personal-fix?source=phone')
-          expect(result.personalEmail.changeLink).toBe('/account-email-change')
+          expect(result.personalEmail.changeLink).toBe(`/customer/${data.crn}/account-email-change`)
           expect(result.dob.changeLink).toBe('/personal-fix?source=dob')
         })
       })
@@ -492,7 +492,7 @@ describe('personalDetailsPresenter', () => {
           expect(result.personalAddress.changeLink).toBe('/personal-fix?source=address')
           expect(result.personalTelephone.changeLink).toBe('/personal-fix?source=phone')
           expect(result.personalEmail.changeLink).toBe('/personal-fix?source=email')
-          expect(result.dob.changeLink).toBe('/account-date-of-birth-change')
+          expect(result.dob.changeLink).toBe(`/customer/${data.crn}/account-date-of-birth-change`)
         })
       })
 

--- a/test/unit/presenters/personal-details-presenter.test.js
+++ b/test/unit/presenters/personal-details-presenter.test.js
@@ -78,7 +78,7 @@ describe('personalDetailsPresenter', () => {
         personalName: {
           fullName: 'John M Doe',
           action: 'Change',
-          changeLink: '/account-name-change'
+          changeLink: `/customer/${data.crn}/account-name-change`
         },
         dob: {
           fullDateOfBirth: '1 January 1990',
@@ -385,7 +385,7 @@ describe('personalDetailsPresenter', () => {
       test('all change links should point to their standard change link', () => {
         const result = personalDetailsPresenter(data, yar, hasValidPersonalDetails, sectionsNeedingUpdate)
 
-        expect(result.personalName.changeLink).toBe('/account-name-change')
+        expect(result.personalName.changeLink).toBe(`/customer/${data.crn}/account-name-change`)
         expect(result.personalAddress.changeLink).toBe('/account-address-change')
         expect(result.personalTelephone.changeLink).toBe('/account-phone-numbers-change')
         expect(result.personalEmail.changeLink).toBe('/account-email-change')
@@ -403,7 +403,7 @@ describe('personalDetailsPresenter', () => {
         test('all change links should point to their standard change link', () => {
           const result = personalDetailsPresenter(data, yar, hasValidPersonalDetails, sectionsNeedingUpdate)
 
-          expect(result.personalName.changeLink).toBe('/account-name-change')
+          expect(result.personalName.changeLink).toBe(`/customer/${data.crn}/account-name-change`)
           expect(result.personalAddress.changeLink).toBe('/account-address-change')
           expect(result.personalTelephone.changeLink).toBe('/account-phone-numbers-change')
           expect(result.personalEmail.changeLink).toBe('/account-email-change')
@@ -420,7 +420,7 @@ describe('personalDetailsPresenter', () => {
         test('all links except the name points to the interrupter journey', () => {
           const result = personalDetailsPresenter(data, yar, hasValidPersonalDetails, sectionsNeedingUpdate)
 
-          expect(result.personalName.changeLink).toBe('/account-name-change')
+          expect(result.personalName.changeLink).toBe(`/customer/${data.crn}/account-name-change`)
           expect(result.personalAddress.changeLink).toBe('/personal-fix?source=address')
           expect(result.personalTelephone.changeLink).toBe('/personal-fix?source=phone')
           expect(result.personalEmail.changeLink).toBe('/personal-fix?source=email')

--- a/test/unit/presenters/personal/personal-name-change-presenter.test.js
+++ b/test/unit/presenters/personal/personal-name-change-presenter.test.js
@@ -1,0 +1,172 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach } from 'vitest'
+
+// Thing under test
+import { personalNameChangePresenter } from '../../../../src/presenters/personal/personal-name-change-presenter.js'
+
+describe('personalNameChangePresenter', () => {
+  let data
+  let payload
+  const crn = '1234567890'
+
+  beforeEach(() => {
+    data = {
+      info: {
+        userName: 'John Doe',
+        fullName: {
+          first: 'John',
+          middle: 'M',
+          last: 'Doe'
+        }
+      },
+      changePersonalName: {}
+    }
+  })
+
+  describe('when provided with personal name change data', () => {
+    test('it correctly presents the data', () => {
+      const result = personalNameChangePresenter(data, undefined, crn)
+
+      expect(result).toEqual({
+        backLink: { href: '/customer/1234567890/details' },
+        pageTitle: 'What is your full name?',
+        metaDescription: 'Update the full name for your personal account.',
+        userName: 'John Doe',
+        first: 'John',
+        middle: 'M',
+        last: 'Doe'
+      })
+    })
+  })
+
+  describe('the "userName" property', () => {
+    describe('when the userName property is missing', () => {
+      beforeEach(() => {
+        delete data.info.userName
+      })
+
+      test('it should return userName as null', () => {
+        const result = personalNameChangePresenter(data, undefined, crn)
+
+        expect(result.userName).toEqual(null)
+      })
+    })
+  })
+
+  describe('the "first" property', () => {
+    describe('when provided with a payload', () => {
+      beforeEach(() => {
+        payload = { first: 'Jane' }
+      })
+
+      test('it should return the payload as the first property', () => {
+        const result = personalNameChangePresenter(data, payload, crn)
+
+        expect(result.first).toEqual('Jane')
+      })
+    })
+
+    describe('when no payload is provided but a changed first name', () => {
+      beforeEach(() => {
+        data.changePersonalName.first = 'Jack'
+      })
+
+      test('it should return the changed name as the first property', () => {
+        const result = personalNameChangePresenter(data, undefined, crn)
+
+        expect(result.first).toEqual('Jack')
+      })
+    })
+
+    describe('when no payload and no changed name is provided', () => {
+      beforeEach(() => {
+        delete data.changePersonalName.first
+        payload = {}
+      })
+
+      test('it should default to the original first name', () => {
+        const result = personalNameChangePresenter(data, payload, crn)
+
+        expect(result.first).toEqual('John')
+      })
+    })
+  })
+
+  describe('the "middle" property', () => {
+    describe('when provided with a payload', () => {
+      beforeEach(() => {
+        payload = { middle: 'P' }
+      })
+
+      test('it should return the payload as the middle property', () => {
+        const result = personalNameChangePresenter(data, payload, crn)
+
+        expect(result.middle).toEqual('P')
+      })
+    })
+
+    describe('when no payload is provided but a changed middle names', () => {
+      beforeEach(() => {
+        data.changePersonalName.middle = 'A'
+      })
+
+      test('it should return the changed name as the middle property', () => {
+        const result = personalNameChangePresenter(data, undefined, crn)
+
+        expect(result.middle).toEqual('A')
+      })
+    })
+
+    describe('when no payload and no changed name is provided', () => {
+      beforeEach(() => {
+        delete data.changePersonalName.middle
+        payload = {}
+      })
+
+      test('it should default to the original middle names', () => {
+        const result = personalNameChangePresenter(data, payload, crn)
+
+        expect(result.middle).toEqual('M')
+      })
+    })
+  })
+
+  describe('the "last" property', () => {
+    describe('when provided with a payload', () => {
+      beforeEach(() => {
+        payload = { last: 'Smith' }
+      })
+
+      test('it should return last as the payload', () => {
+        const result = personalNameChangePresenter(data, payload, crn)
+
+        expect(result.last).toEqual('Smith')
+      })
+    })
+
+    describe('when no payload is provided but a changed last name', () => {
+      beforeEach(() => {
+        data.changePersonalName.last = 'Jones'
+      })
+
+      test('it should return the changed name as the last property', () => {
+        const result = personalNameChangePresenter(data, undefined, crn)
+
+        expect(result.last).toEqual('Jones')
+      })
+    })
+
+    describe('when no payload and no changed name is provided', () => {
+      beforeEach(() => {
+        delete data.changePersonalName.last
+        payload = {}
+      })
+
+      test('it should default to the original last name', () => {
+        const result = personalNameChangePresenter(data, payload, crn)
+
+        expect(result.last).toEqual('Doe')
+      })
+    })
+  })
+})

--- a/test/unit/presenters/personal/personal-name-change-presenter.test.js
+++ b/test/unit/presenters/personal/personal-name-change-presenter.test.js
@@ -169,4 +169,22 @@ describe('personalNameChangePresenter', () => {
       })
     })
   })
+
+  describe('the "backLink" property', () => {
+    describe('when a crn is provided', () => {
+      test('it should link to the customer details page', () => {
+        const result = personalNameChangePresenter(data, undefined, crn)
+
+        expect(result.backLink).toEqual({ href: '/customer/1234567890/details' })
+      })
+    })
+
+    describe('when a crn is not provided', () => {
+      test('it should link to the search-crn page', () => {
+        const result = personalNameChangePresenter(data, undefined, undefined)
+
+        expect(result.backLink).toEqual({ href: '/search-crn' })
+      })
+    })
+  })
 })

--- a/test/unit/presenters/personal/personal-name-check-presenter.test.js
+++ b/test/unit/presenters/personal/personal-name-check-presenter.test.js
@@ -1,0 +1,82 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach } from 'vitest'
+
+// Thing under test
+import { personalNameCheckPresenter } from '../../../../src/presenters/personal/personal-name-check-presenter.js'
+
+describe('personalNameCheckPresenter', () => {
+  let data
+  const crn = '1234567890'
+
+  beforeEach(() => {
+    data = {
+      info: {
+        userName: 'John Doe',
+        fullName: {
+          first: 'John',
+          middle: 'M',
+          last: 'Doe'
+        }
+      }
+    }
+  })
+
+  describe('when provided with personal name check data', () => {
+    test('it correctly presents the data', () => {
+      const result = personalNameCheckPresenter(data, crn)
+
+      expect(result).toEqual({
+        backLink: { href: '/customer/1234567890/account-name-change' },
+        changeLink: '/customer/1234567890/account-name-change',
+        pageTitle: 'Check your name is correct before submitting',
+        metaDescription: 'Check the full name for your personal account is correct.',
+        userName: 'John Doe',
+        fullName: 'John M Doe'
+      })
+    })
+  })
+
+  describe('the "userName" property', () => {
+    describe('when the userName property is missing', () => {
+      beforeEach(() => {
+        delete data.info.userName
+      })
+
+      test('it should return userName as null', () => {
+        const result = personalNameCheckPresenter(data, crn)
+
+        expect(result.userName).toEqual(null)
+      })
+    })
+  })
+
+  describe('the "fullName" property', () => {
+    describe('when provided with a changed personal name', () => {
+      beforeEach(() => {
+        data.changePersonalName = {
+          first: 'Jane',
+          middle: 'A',
+          last: 'Smith'
+        }
+      })
+
+      test('it should return the changed name as the fullName property', () => {
+        const result = personalNameCheckPresenter(data, crn)
+
+        expect(result.fullName).toEqual('Jane A Smith')
+      })
+    })
+
+    describe('when changePersonalName is missing', () => {
+      beforeEach(() => {
+        delete data.changePersonalName
+      })
+
+      test('it should default to the original name', () => {
+        const result = personalNameCheckPresenter(data, crn)
+
+        expect(result.fullName).toEqual('John M Doe')
+      })
+    })
+  })
+})

--- a/test/unit/routes/customer/customer-details-routes.test.js
+++ b/test/unit/routes/customer/customer-details-routes.test.js
@@ -52,7 +52,8 @@ describe('customer details', () => {
           },
           yar: {
             get: vi.fn(),
-            set: vi.fn()
+            set: vi.fn(),
+            clear: vi.fn()
           }
         }
 
@@ -76,6 +77,12 @@ describe('customer details', () => {
         expect(validatePersonalDetailsService).toHaveBeenCalledWith(personalDetails)
         expect(personalDetailsPresenter).toHaveBeenCalledWith(personalDetails, request.yar, true, [])
         expect(h.view).toHaveBeenCalledWith('personal/personal-details.njk', pageData)
+      })
+
+      test('it clears any pending personal details update from the session', async () => {
+        await getCustomerDetails.handler(request, h)
+
+        expect(request.yar.clear).toHaveBeenCalledWith('personalDetailsUpdate')
       })
 
       test('it passes validation results to the presenter when sections need updating', async () => {

--- a/test/unit/routes/customer/personal-name-change-routes.test.js
+++ b/test/unit/routes/customer/personal-name-change-routes.test.js
@@ -1,0 +1,198 @@
+// Test framework dependencies
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+// Things we need to mock
+import { setSessionData } from '../../../../src/utils/session/set-session-data.js'
+import { fetchPersonalChangeService } from '../../../../src/services/personal/fetch-personal-change-service.js'
+
+// Thing under test
+import { personalNameChangeRoutes } from '../../../../src/routes/customer/personal-name-change-routes.js'
+const [getPersonalNameChange, postPersonalNameChange] = personalNameChangeRoutes
+
+// Mocks
+vi.mock('../../../../src/utils/session/set-session-data.js', () => ({
+  setSessionData: vi.fn()
+}))
+
+vi.mock('../../../../src/services/personal/fetch-personal-change-service.js', () => ({
+  fetchPersonalChangeService: vi.fn()
+}))
+
+describe('personal name change', () => {
+  let request
+  let h
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    request = {
+      params: { crn: '1234567890' },
+      auth: { credentials: { email: 'test@example.com' } },
+      yar: {},
+      payload: {}
+    }
+
+    const responseStub = {
+      code: vi.fn().mockReturnThis(),
+      takeover: vi.fn().mockReturnThis()
+    }
+
+    h = {
+      redirect: vi.fn(),
+      view: vi.fn(() => responseStub)
+    }
+  })
+
+  describe('GET /customer/{crn}/account-name-change', () => {
+    describe('when a request is valid', () => {
+      beforeEach(() => {
+        fetchPersonalChangeService.mockResolvedValue(getMockData())
+      })
+
+      test('should have the correct method and path configured', () => {
+        expect(getPersonalNameChange.method).toBe('GET')
+        expect(getPersonalNameChange.path).toBe('/customer/{crn}/account-name-change')
+      })
+
+      test('it fetches the data from the session', async () => {
+        await getPersonalNameChange.handler(request, h)
+
+        expect(fetchPersonalChangeService).toHaveBeenCalledWith(request.yar, '1234567890', 'test@example.com', 'changePersonalName')
+      })
+
+      test('it renders the personal-name-change view with correct page data', async () => {
+        await getPersonalNameChange.handler(request, h)
+
+        expect(h.view).toHaveBeenCalledWith('personal/personal-name-change', getPageData())
+      })
+    })
+
+    describe('when the crn fails validation', () => {
+      beforeEach(() => {
+        request.params.crn = 'invalid-crn'
+      })
+
+      test('it redirects to the search-crn page and does not fetch data', async () => {
+        await getPersonalNameChange.handler(request, h)
+
+        expect(h.redirect).toHaveBeenCalledWith('/search-crn')
+        expect(fetchPersonalChangeService).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('POST /customer/{crn}/account-name-change', () => {
+    beforeEach(() => {
+      request.payload = {
+        first: 'John',
+        middle: 'A',
+        last: 'Doe'
+      }
+
+      fetchPersonalChangeService.mockResolvedValue({ ...getMockData(), changePersonalName: request.payload })
+    })
+
+    test('should have the correct method and path configured', () => {
+      expect(postPersonalNameChange.method).toBe('POST')
+      expect(postPersonalNameChange.path).toBe('/customer/{crn}/account-name-change')
+    })
+
+    describe('and the validation passes', () => {
+      test('it sets the session data and redirects to the check page', async () => {
+        await postPersonalNameChange.options.handler(request, h)
+
+        expect(setSessionData).toHaveBeenCalledWith(
+          request.yar,
+          'personalDetailsUpdate',
+          'changePersonalName',
+          request.payload
+        )
+        expect(h.redirect).toHaveBeenCalledWith('/customer/1234567890/account-name-check')
+      })
+    })
+
+    describe('and the validation fails', () => {
+      let err
+
+      beforeEach(() => {
+        err = {
+          details: [
+            {
+              message: 'Enter first name',
+              path: ['first'],
+              type: 'string.empty'
+            }
+          ]
+        }
+      })
+
+      test('it fetches the personal details', async () => {
+        await postPersonalNameChange.options.validate.failAction(request, h, err)
+
+        expect(fetchPersonalChangeService).toHaveBeenCalledWith(
+          request.yar,
+          '1234567890',
+          'test@example.com',
+          'changePersonalName'
+        )
+      })
+
+      test('it returns the page successfully with the error summary banner', async () => {
+        await postPersonalNameChange.options.validate.failAction(request, h, err)
+
+        expect(h.view).toHaveBeenCalledWith('personal/personal-name-change', getPageDataError())
+      })
+
+      test('it should handle undefined errors', async () => {
+        await postPersonalNameChange.options.validate.failAction(request, h, [])
+
+        const pageData = getPageDataError()
+        pageData.errors = {}
+
+        expect(h.view).toHaveBeenCalledWith('personal/personal-name-change', pageData)
+      })
+    })
+  })
+})
+
+const getMockData = () => {
+  return {
+    info: {
+      userName: 'John Doe',
+      fullName: {
+        first: 'John',
+        middle: 'M',
+        last: 'Doe'
+      }
+    }
+  }
+}
+
+const getPageData = () => {
+  return {
+    backLink: { href: '/customer/1234567890/details' },
+    pageTitle: 'What is your full name?',
+    metaDescription: 'Update the full name for your personal account.',
+    userName: 'John Doe',
+    first: 'John',
+    middle: 'M',
+    last: 'Doe'
+  }
+}
+
+const getPageDataError = () => {
+  return {
+    backLink: { href: '/customer/1234567890/details' },
+    pageTitle: 'What is your full name?',
+    metaDescription: 'Update the full name for your personal account.',
+    userName: 'John Doe',
+    first: 'John',
+    middle: 'A',
+    last: 'Doe',
+    errors: {
+      first: {
+        text: 'Enter first name'
+      }
+    }
+  }
+}

--- a/test/unit/routes/customer/personal-name-check-routes.test.js
+++ b/test/unit/routes/customer/personal-name-check-routes.test.js
@@ -1,0 +1,136 @@
+// Test framework dependencies
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+// Things we need to mock
+import { fetchPersonalChangeService } from '../../../../src/services/personal/fetch-personal-change-service.js'
+import { updatePersonalNameChangeService } from '../../../../src/services/personal/update-personal-name-change-service.js'
+
+// Thing under test
+import { personalNameCheckRoutes } from '../../../../src/routes/customer/personal-name-check-routes.js'
+const [getPersonalNameCheck, postPersonalNameCheck] = personalNameCheckRoutes
+
+// Mocks
+vi.mock('../../../../src/services/personal/fetch-personal-change-service.js', () => ({
+  fetchPersonalChangeService: vi.fn()
+}))
+
+vi.mock('../../../../src/services/personal/update-personal-name-change-service.js', () => ({
+  updatePersonalNameChangeService: vi.fn()
+}))
+
+describe('personal name check', () => {
+  let request
+  let h
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    request = {
+      params: { crn: '1234567890' },
+      auth: { credentials: { email: 'test@example.com' } },
+      yar: {}
+    }
+  })
+
+  describe('GET /customer/{crn}/account-name-check', () => {
+    describe('when a request is valid', () => {
+      beforeEach(() => {
+        h = {
+          view: vi.fn().mockReturnValue({}),
+          redirect: vi.fn()
+        }
+
+        fetchPersonalChangeService.mockResolvedValue(getMockData())
+      })
+
+      test('should have the correct method and path configured', () => {
+        expect(getPersonalNameCheck.method).toBe('GET')
+        expect(getPersonalNameCheck.path).toBe('/customer/{crn}/account-name-check')
+      })
+
+      test('it fetches the data from the session', async () => {
+        await getPersonalNameCheck.handler(request, h)
+
+        expect(fetchPersonalChangeService).toHaveBeenCalledWith(request.yar, '1234567890', 'test@example.com', 'changePersonalName')
+      })
+
+      test('should render personal-name-check view with page data', async () => {
+        await getPersonalNameCheck.handler(request, h)
+
+        expect(h.view).toHaveBeenCalledWith('personal/personal-name-check', getPageData())
+      })
+    })
+
+    describe('when the crn fails validation', () => {
+      beforeEach(() => {
+        h = {
+          view: vi.fn(),
+          redirect: vi.fn().mockReturnValue({})
+        }
+
+        request.params.crn = 'invalid-crn'
+      })
+
+      test('it redirects to the search-crn page and does not fetch data', async () => {
+        await getPersonalNameCheck.handler(request, h)
+
+        expect(h.redirect).toHaveBeenCalledWith('/search-crn')
+        expect(fetchPersonalChangeService).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('POST /customer/{crn}/account-name-check', () => {
+    beforeEach(() => {
+      h = {
+        redirect: vi.fn(() => h)
+      }
+    })
+
+    test('should have the correct method and path configured', () => {
+      expect(postPersonalNameCheck.method).toBe('POST')
+      expect(postPersonalNameCheck.path).toBe('/customer/{crn}/account-name-check')
+    })
+
+    test('it calls updatePersonalNameChangeService with yar, crn and email', async () => {
+      await postPersonalNameCheck.handler(request, h)
+
+      expect(updatePersonalNameChangeService).toHaveBeenCalledWith(request.yar, '1234567890', 'test@example.com')
+    })
+
+    test('it redirects to the customer details page', async () => {
+      await postPersonalNameCheck.handler(request, h)
+
+      expect(h.redirect).toHaveBeenCalledWith('/customer/1234567890/details')
+    })
+  })
+})
+
+const getMockData = () => {
+  return {
+    info: {
+      userName: 'John Doe',
+      fullName: {
+        first: 'John',
+        middle: 'M',
+        last: 'Doe'
+      }
+    },
+    changePersonalName: {
+      first: 'Jane',
+      middle: 'A',
+      last: 'Smith'
+    }
+  }
+}
+
+const getPageData = () => {
+  return {
+    backLink: { href: '/customer/1234567890/account-name-change' },
+    changeLink: '/customer/1234567890/account-name-change',
+    pageTitle: 'Check your name is correct before submitting',
+    metaDescription: 'Check the full name for your personal account is correct.',
+    userName: 'John Doe',
+    fullName: 'Jane A Smith'
+  }
+}

--- a/test/unit/services/personal/fetch-personal-change-service.test.js
+++ b/test/unit/services/personal/fetch-personal-change-service.test.js
@@ -1,0 +1,77 @@
+// Test framework dependencies
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+// Things we need to mock
+import { fetchPersonalDetailsService } from '../../../../src/services/fetch-personal-details-service.js'
+
+// Thing under test
+import { fetchPersonalChangeService } from '../../../../src/services/personal/fetch-personal-change-service.js'
+
+// Mocks
+vi.mock('../../../../src/services/fetch-personal-details-service.js', () => ({
+  fetchPersonalDetailsService: vi.fn()
+}))
+
+describe('fetchPersonalChangeService', () => {
+  let yar
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    yar = { get: vi.fn().mockReturnValue({}) }
+
+    fetchPersonalDetailsService.mockResolvedValue({
+      crn: '1234567890',
+      info: {
+        userName: 'John Doe',
+        fullName: { first: 'John', middle: 'M', last: 'Doe' }
+      }
+    })
+  })
+
+  test('it fetches the personal details for the given crn and email', async () => {
+    await fetchPersonalChangeService(yar, '1234567890', 'test@example.com', 'changePersonalName')
+
+    expect(fetchPersonalDetailsService).toHaveBeenCalledWith('1234567890', 'test@example.com')
+  })
+
+  describe('when the session has a matching change', () => {
+    beforeEach(() => {
+      yar.get.mockReturnValue({ changePersonalName: { first: 'Jane', middle: 'A', last: 'Smith' } })
+    })
+
+    test('it merges the session change into the personal details', async () => {
+      const result = await fetchPersonalChangeService(yar, '1234567890', 'test@example.com', 'changePersonalName')
+
+      expect(result.changePersonalName).toEqual({ first: 'Jane', middle: 'A', last: 'Smith' })
+    })
+  })
+
+  describe('when passed an array of fields', () => {
+    beforeEach(() => {
+      yar.get.mockReturnValue({
+        changePersonalName: { first: 'Jane' },
+        changePersonalEmail: 'jane@example.com'
+      })
+    })
+
+    test('it merges each matching field that exists in the session', async () => {
+      const result = await fetchPersonalChangeService(yar, '1234567890', 'test@example.com', ['changePersonalName', 'changePersonalEmail'])
+
+      expect(result.changePersonalName).toEqual({ first: 'Jane' })
+      expect(result.changePersonalEmail).toEqual('jane@example.com')
+    })
+  })
+
+  describe('when there is no session data', () => {
+    beforeEach(() => {
+      yar.get.mockReturnValue(undefined)
+    })
+
+    test('it returns the personal details unchanged', async () => {
+      const result = await fetchPersonalChangeService(yar, '1234567890', 'test@example.com', 'changePersonalName')
+
+      expect(result.changePersonalName).toBeUndefined()
+    })
+  })
+})

--- a/test/unit/services/personal/update-personal-name-change-service.test.js
+++ b/test/unit/services/personal/update-personal-name-change-service.test.js
@@ -1,0 +1,131 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+// Things we need to mock
+import { mutations } from '@defra/fcp-sfd-frontend-engine'
+import { fetchPersonalChangeService } from '../../../../src/services/personal/fetch-personal-change-service.js'
+import { flashNotification } from '../../../../src/utils/notifications/flash-notification.js'
+import { updateDalService } from '../../../../src/services/DAL/update-dal-service.js'
+
+// Thing under test
+import { updatePersonalNameChangeService } from '../../../../src/services/personal/update-personal-name-change-service.js'
+
+// Mocks
+vi.mock('../../../../src/services/personal/fetch-personal-change-service.js', () => ({
+  fetchPersonalChangeService: vi.fn()
+}))
+
+vi.mock('../../../../src/utils/notifications/flash-notification.js', () => ({
+  flashNotification: vi.fn()
+}))
+
+vi.mock('../../../../src/services/DAL/update-dal-service.js', () => ({
+  updateDalService: vi.fn().mockResolvedValue({})
+}))
+
+describe('updatePersonalNameChangeService', () => {
+  let yar
+  let crn
+  let email
+  let data
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    crn = '1234567890'
+    email = 'test@example.com'
+
+    data = {
+      crn,
+      info: {
+        userName: 'John Doe',
+        fullName: { first: 'John', middle: 'M', last: 'Doe' }
+      },
+      changePersonalName: {
+        first: 'Jane',
+        last: 'Smith',
+        middle: 'A'
+      }
+    }
+
+    fetchPersonalChangeService.mockResolvedValue(data)
+
+    yar = { clear: vi.fn() }
+  })
+
+  describe('when called', () => {
+    test('it fetches the personal details with the crn and email', async () => {
+      await updatePersonalNameChangeService(yar, crn, email)
+
+      expect(fetchPersonalChangeService).toHaveBeenCalledWith(yar, crn, email, 'changePersonalName')
+    })
+
+    test('it calls updateDalService with the correct mutation and variables', async () => {
+      await updatePersonalNameChangeService(yar, crn, email)
+
+      expect(updateDalService).toHaveBeenCalledWith(mutations.updateCustomerName, {
+        input: {
+          first: 'Jane',
+          last: 'Smith',
+          middle: 'A',
+          crn
+        }
+      }, email)
+    })
+
+    describe('when middle names are null', () => {
+      beforeEach(() => {
+        data.changePersonalName.middle = null
+      })
+
+      test('it calls updateDalService with a null middle name', async () => {
+        await updatePersonalNameChangeService(yar, crn, email)
+
+        expect(updateDalService).toHaveBeenCalledWith(mutations.updateCustomerName, {
+          input: {
+            first: 'Jane',
+            last: 'Smith',
+            middle: null,
+            crn
+          }
+        }, email)
+      })
+    })
+
+    test('it clears the personalDetailsUpdate from session', async () => {
+      await updatePersonalNameChangeService(yar, crn, email)
+
+      expect(yar.clear).toHaveBeenCalledWith('personalDetailsUpdate')
+    })
+
+    test('adds a flash notification confirming the change in data', async () => {
+      await updatePersonalNameChangeService(yar, crn, email)
+
+      expect(flashNotification).toHaveBeenCalledWith(yar, 'Success', 'You have updated your full name')
+    })
+  })
+
+  describe('when there is no changePersonalName in session data', () => {
+    beforeEach(() => {
+      data.changePersonalName = undefined
+    })
+
+    test('it returns early and does not call updateDalService', async () => {
+      await updatePersonalNameChangeService(yar, crn, email)
+
+      expect(updateDalService).not.toHaveBeenCalled()
+    })
+
+    test('it does not add a flash notification', async () => {
+      await updatePersonalNameChangeService(yar, crn, email)
+
+      expect(flashNotification).not.toHaveBeenCalled()
+    })
+
+    test('it does not clear personalDetailsUpdate from session', async () => {
+      await updatePersonalNameChangeService(yar, crn, email)
+
+      expect(yar.clear).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/test/unit/utils/session/set-session-data.test.js
+++ b/test/unit/utils/session/set-session-data.test.js
@@ -5,43 +5,44 @@ import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { setSessionData } from '../../../../src/utils/session/set-session-data.js'
 
 describe('setSessionData', () => {
-  describe('when called with a data, key and a value', () => {
-    let data
-    let key
-    let value
-    let yar
+  let data
+  let key
+  let value
+  let yar
+  let sessionData
 
-    beforeEach(() => {
-      vi.clearAllMocks()
+  beforeEach(() => {
+    vi.clearAllMocks()
 
-      const sessionData = {
+    sessionData = {
+      businessAddress: {
+        businessName: 'Diddly Squat Farm',
         businessAddress: {
-          businessName: 'Diddly Squat Farm',
-          businessAddress: {
-            address1: '10 Skirbeck Way',
-            city: 'Maidstone',
-            postcode: 'SK22 1DL',
-            country: 'United Kingdom'
-          }
+          address1: '10 Skirbeck Way',
+          city: 'Maidstone',
+          postcode: 'SK22 1DL',
+          country: 'United Kingdom'
         }
       }
+    }
 
-      // Mock yar session manager
-      yar = {
-        get: (key) => sessionData[key],
-        set: (key, value) => { sessionData[key] = value }
-      }
+    // Mock yar session manager
+    yar = {
+      get: (key) => sessionData[key],
+      set: (key, value) => { sessionData[key] = value }
+    }
 
-      data = {
-        address1: 'Diddly Squat Farm',
-        city: 'Chipping Norton',
-        country: 'United Kingdom'
-      }
+    data = {
+      address1: 'Diddly Squat Farm',
+      city: 'Chipping Norton',
+      country: 'United Kingdom'
+    }
 
-      key = 'businessAddress'
-      value = 'businessAddress'
-    })
+    key = 'businessAddress'
+    value = 'businessAddress'
+  })
 
+  describe('when called with existing session data', () => {
     test('it sets the payload on the yar session object using the value', () => {
       setSessionData(yar, key, value, data)
 
@@ -62,6 +63,24 @@ describe('setSessionData', () => {
 
       expect(result).toEqual({
         businessName: 'Diddly Squat Farm',
+        businessAddress: {
+          address1: 'Diddly Squat Farm',
+          city: 'Chipping Norton',
+          country: 'United Kingdom'
+        }
+      })
+    })
+  })
+
+  describe('when no session data exists yet', () => {
+    beforeEach(() => {
+      sessionData = {} // clear everything
+    })
+
+    test('it creates the object and sets the value', () => {
+      const result = setSessionData(yar, key, value, data)
+
+      expect(result).toEqual({
         businessAddress: {
           address1: 'Diddly Squat Farm',
           city: 'Chipping Norton',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FLS2-53

## Summary
Adds the internal (staff-facing) journey to view and update a customer's full name, so caseworkers can keep customer records up to date. It recreates the equivalent customer-facing journey from the external service: staff open a customer's personal details, change the full name, review it, and submit — with field validation and a success confirmation banner. Shared, non-view logic (the full-name formatter and the update mutation) is consumed from the frontend engine.

## Changes
- Adds the full name change and check pages, scoped to a customer (CRN)
- Wires the journey into the existing customer details page
- Validates the name fields and persists the change via the DAL
- Adds unit tests for the new routes, presenters and services

## Notes
- Depends on the matching `@defra/fcp-sfd-frontend-engine` changes (shared `formatFullName` + `updateCustomerName` mutation) being released and the dependency bumped.
- RBAC/permission gating is out of scope for this ticket — built assuming a full-permissions user.
