### PR TITLE
FLS2-57: Add Personal Email Change Journey

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@defra/fcp-sfd-frontend-engine": "0.10.0",
+        "@defra/fcp-sfd-frontend-engine": "0.12.0",
         "@defra/hapi-tracing": "1.30.0",
         "@elastic/ecs-pino-format": "1.5.0",
         "@hapi/bell": "13.1.0",
@@ -491,9 +491,9 @@
       "license": "MIT"
     },
     "node_modules/@defra/fcp-sfd-frontend-engine": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.10.0.tgz",
-      "integrity": "sha512-ewZLB6CryrTXtBQUSZB1rPPEIq4j1BtvfCkefkWODTOHyVFX32Sb2Gb/wczE7zZzgRFduCZnEUy0DTgkovhMNA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.12.0.tgz",
+      "integrity": "sha512-EJY88La4+iWo9V/ZOTemU6MbCf7trxnLBCabBR4vRKJ0C3/rRWXXdtZDzs3hI8x59sKRD5JgN58jqFmTO9OE8w==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "joi": "18.2.3"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "license": "OGL-UK-3.0",
   "dependencies": {
-    "@defra/fcp-sfd-frontend-engine": "0.10.0",
+    "@defra/fcp-sfd-frontend-engine": "0.12.0",
     "@defra/hapi-tracing": "1.30.0",
     "@elastic/ecs-pino-format": "1.5.0",
     "@hapi/bell": "13.1.0",

--- a/src/presenters/personal/personal-details-presenter.js
+++ b/src/presenters/personal/personal-details-presenter.js
@@ -5,7 +5,7 @@
 
 import moment from 'moment'
 import { presenters } from '@defra/fcp-sfd-frontend-engine'
-import { config } from '../config/index.js'
+import { config } from '../../config/index.js'
 
 const personalDetailsPresenter = (data, yar, hasValidPersonalDetails, sectionsNeedingUpdate) => {
   const changeLinks = formatChangeLinks(data.crn, hasValidPersonalDetails, sectionsNeedingUpdate)

--- a/src/presenters/personal/personal-email-change-presenter.js
+++ b/src/presenters/personal/personal-email-change-presenter.js
@@ -1,0 +1,18 @@
+/*
+ * Formats data ready for presenting in the `/customer/{CRN}/details/account-email-change` page
+ * @module personalEmailChangePresenter
+ */
+
+const personalEmailChangePresenter = (personalDetails, payload, crn) => {
+  return {
+    backLink: { href: crn ? `/customer/${crn}/details` : '/search-crn' },
+    pageTitle: 'What is your personal email address?',
+    metaDescription: 'Update the email address for your personal account.',
+    userName: personalDetails.info.userName ?? null,
+    personalEmail: payload ?? personalDetails.changePersonalEmail ?? personalDetails.contact.email
+  }
+}
+
+export {
+  personalEmailChangePresenter
+}

--- a/src/presenters/personal/personal-email-check-presenter.js
+++ b/src/presenters/personal/personal-email-check-presenter.js
@@ -1,0 +1,19 @@
+/**
+ * Formats data ready for presenting in the `/customer/{CRN}/details/account-email-check` page
+ * @module personalEmailCheckPresenter
+ */
+
+const personalEmailCheckPresenter = (personalDetails, crn) => {
+  return {
+    backLink: { href: `/customer/${crn}/account-email-change` },
+    changeLink: `/customer/${crn}/account-email-change`,
+    pageTitle: 'Check your personal email address is correct before submitting',
+    metaDescription: 'Check the email address for your personal account is correct.',
+    userName: personalDetails.info.userName ?? null,
+    personalEmail: personalDetails.changePersonalEmail ?? personalDetails.contact.email
+  }
+}
+
+export {
+  personalEmailCheckPresenter
+}

--- a/src/routes/customer/customer-details-routes.js
+++ b/src/routes/customer/customer-details-routes.js
@@ -1,7 +1,7 @@
 import { schemas } from '@defra/fcp-sfd-frontend-engine'
 
 import { fetchPersonalDetailsService } from '../../services/fetch-personal-details-service.js'
-import { personalDetailsPresenter } from '../../presenters/personal-details-presenter.js'
+import { personalDetailsPresenter } from '../../presenters/personal/personal-details-presenter.js'
 import { validatePersonalDetailsService } from '../../services/personal/validate-personal-details-service.js'
 
 const getCustomerDetails = {

--- a/src/routes/customer/personal-email-change-routes.js
+++ b/src/routes/customer/personal-email-change-routes.js
@@ -1,0 +1,61 @@
+import { schemas, utils, constants } from '@defra/fcp-sfd-frontend-engine'
+
+import { personalEmailChangePresenter } from '../../presenters/personal/personal-email-change-presenter.js'
+import { fetchPersonalChangeService } from '../../services/personal/fetch-personal-change-service.js'
+import { setSessionData } from '../../utils/session/set-session-data.js'
+
+const getPersonalEmailChange = {
+  method: 'GET',
+  path: '/customer/{crn}/account-email-change',
+  handler: async (request, h) => {
+    const { params, auth, yar } = request
+    const { crn } = params
+
+    const { error } = schemas.customer.crn.validate({ crn })
+
+    if (error) {
+      return h.redirect('/search-crn')
+    }
+
+    const email = auth.credentials?.email
+    const personalDetails = await fetchPersonalChangeService(yar, crn, email, 'changePersonalEmail')
+    const pageData = personalEmailChangePresenter(personalDetails, undefined, crn)
+
+    return h.view('personal/personal-email-change', pageData)
+  }
+}
+
+const postPersonalEmailChange = {
+  method: 'POST',
+  path: '/customer/{crn}/account-email-change',
+  options: {
+    validate: {
+      payload: schemas.personal.email,
+      options: { abortEarly: false },
+      failAction: async (request, h, err) => {
+        const { params, auth, yar, payload } = request
+        const { crn } = params
+
+        const email = auth.credentials?.email
+        const errors = utils.formatValidationErrors(err.details || [])
+        const personalDetails = await fetchPersonalChangeService(yar, crn, email, 'changePersonalEmail')
+        const pageData = personalEmailChangePresenter(personalDetails, payload.personalEmail, crn)
+
+        return h.view('personal/personal-email-change', { ...pageData, errors }).code(constants.statusCodes.BAD_REQUEST).takeover()
+      }
+    },
+    handler: async (request, h) => {
+      const { params, yar, payload } = request
+      const { crn } = params
+
+      setSessionData(yar, 'personalDetailsUpdate', 'changePersonalEmail', payload.personalEmail)
+
+      return h.redirect(`/customer/${crn}/account-email-check`)
+    }
+  }
+}
+
+export const personalEmailChangeRoutes = [
+  getPersonalEmailChange,
+  postPersonalEmailChange
+]

--- a/src/routes/customer/personal-email-check-routes.js
+++ b/src/routes/customer/personal-email-check-routes.js
@@ -1,0 +1,45 @@
+import { schemas } from '@defra/fcp-sfd-frontend-engine'
+
+import { personalEmailCheckPresenter } from '../../presenters/personal/personal-email-check-presenter.js'
+import { fetchPersonalChangeService } from '../../services/personal/fetch-personal-change-service.js'
+import { updatePersonalEmailChangeService } from '../../services/personal/update-personal-email-change-service.js'
+
+const getPersonalEmailCheck = {
+  method: 'GET',
+  path: '/customer/{crn}/account-email-check',
+  handler: async (request, h) => {
+    const { params, auth, yar } = request
+    const { crn } = params
+
+    const { error } = schemas.customer.crn.validate({ crn })
+
+    if (error) {
+      return h.redirect('/search-crn')
+    }
+
+    const email = auth.credentials?.email
+    const personalDetails = await fetchPersonalChangeService(yar, crn, email, 'changePersonalEmail')
+    const pageData = personalEmailCheckPresenter(personalDetails, crn)
+
+    return h.view('personal/personal-email-check', pageData)
+  }
+}
+
+const postPersonalEmailCheck = {
+  method: 'POST',
+  path: '/customer/{crn}/account-email-check',
+  handler: async (request, h) => {
+    const { params, auth, yar } = request
+    const { crn } = params
+
+    const email = auth.credentials?.email
+    await updatePersonalEmailChangeService(yar, crn, email)
+
+    return h.redirect(`/customer/${crn}/details`)
+  }
+}
+
+export const personalEmailCheckRoutes = [
+  getPersonalEmailCheck,
+  postPersonalEmailCheck
+]

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -14,6 +14,8 @@ import { businessOverviewRoutes } from './overview/business-routes.js'
 import { customerDetailsRoutes } from './customer/customer-details-routes.js'
 import { personalNameChangeRoutes } from './customer/personal-name-change-routes.js'
 import { personalNameCheckRoutes } from './customer/personal-name-check-routes.js'
+import { personalEmailChangeRoutes } from './customer/personal-email-change-routes.js'
+import { personalEmailCheckRoutes } from './customer/personal-email-check-routes.js'
 import { businessDetailsRoutes } from './business/business-details-routes.js'
 
 export const routes = [
@@ -33,5 +35,7 @@ export const routes = [
   ...customerDetailsRoutes,
   ...personalNameChangeRoutes,
   ...personalNameCheckRoutes,
+  ...personalEmailChangeRoutes,
+  ...personalEmailCheckRoutes,
   ...businessDetailsRoutes
 ]

--- a/src/services/personal/update-personal-email-change-service.js
+++ b/src/services/personal/update-personal-email-change-service.js
@@ -1,0 +1,43 @@
+/**
+ * Service to update a personal email address
+ *
+ * Fetches the pending personal email change from the session
+ * Calls the DAL to persist the updated email using updateDalService
+ * Clears the cached personal details data from the session
+ * Displays a success flash notification to the user
+ *
+ * @module updatePersonalEmailChangeService
+ */
+
+import { mutations } from '@defra/fcp-sfd-frontend-engine'
+
+import { fetchPersonalChangeService } from './fetch-personal-change-service.js'
+import { flashNotification } from '../../utils/notifications/flash-notification.js'
+import { updateDalService } from '../DAL/update-dal-service.js'
+
+const updatePersonalEmailChangeService = async (yar, crn, email) => {
+  const personalDetails = await fetchPersonalChangeService(yar, crn, email, 'changePersonalEmail')
+
+  if (!personalDetails.changePersonalEmail) {
+    return
+  }
+
+  const variables = {
+    input: {
+      email: {
+        address: personalDetails.changePersonalEmail
+      },
+      crn: personalDetails.crn
+    }
+  }
+
+  await updateDalService(mutations.updateCustomerEmail, variables, email)
+
+  yar.clear('personalDetailsUpdate')
+
+  flashNotification(yar, 'Success', 'You have updated your personal email address')
+}
+
+export {
+  updatePersonalEmailChangeService
+}

--- a/src/views/personal/personal-email-change.njk
+++ b/src/views/personal/personal-email-change.njk
@@ -13,12 +13,7 @@
   {% if errors %}
     {{ govukErrorSummary({
       titleText: "There is a problem",
-      errorList: [
-        {
-          text: errors.personalEmail.text,
-          href: "#personal-email"
-        }
-      ]
+      errorList: errors | toErrorList
     }) }}
   {% endif %}
 
@@ -35,7 +30,7 @@
             isPageHeading: true
           },
           classes: "govuk-input--width-20",
-          id: "personal-email",
+          id: "personalEmail",
           name: "personalEmail",
           value: personalEmail,
           errorMessage: errors.personalEmail and {

--- a/src/views/personal/personal-email-change.njk
+++ b/src/views/personal/personal-email-change.njk
@@ -22,7 +22,6 @@
     <div class="govuk-grid-column-two-thirds">
       <form method="post" novalidate>
         <input type="hidden" name="crumb" value="{{ crumb }}">
-        <span class="govuk-caption-l text-wrap-no-hyphen">{{ userName }}</span>
         {{ govukInput({
           label: {
             text: pageTitle,

--- a/src/views/personal/personal-email-change.njk
+++ b/src/views/personal/personal-email-change.njk
@@ -1,0 +1,51 @@
+{% extends 'common/layout.njk' %}
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "common/navigation/back-sign-out-link.njk" import appBackSignOutLink with context %}
+
+{% block beforeContent %}
+  {{ appBackSignOutLink({ backLink: backLink, href: backLink.href }) }}
+{% endblock %}
+
+{% block content %}
+  {% if errors %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: [
+        {
+          text: errors.personalEmail.text,
+          href: "#personal-email"
+        }
+      ]
+    }) }}
+  {% endif %}
+
+<div class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post" novalidate>
+        <input type="hidden" name="crumb" value="{{ crumb }}">
+        <span class="govuk-caption-l text-wrap-no-hyphen">{{ userName }}</span>
+        {{ govukInput({
+          label: {
+            text: pageTitle,
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          classes: "govuk-input--width-20",
+          id: "personal-email",
+          name: "personalEmail",
+          value: personalEmail,
+          errorMessage: errors.personalEmail and {
+            text: errors.personalEmail.text
+          }
+        }) }}
+
+        {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/src/views/personal/personal-email-check.njk
+++ b/src/views/personal/personal-email-check.njk
@@ -14,7 +14,6 @@
     <div class="govuk-grid-column-two-thirds">
       <form method="post" novalidate>
         <input type="hidden" name="crumb" value="{{ crumb }}">
-        <span class="govuk-caption-l text-wrap-no-hyphen">{{ userName }}</span>
         <h1 class="govuk-heading-l">
           {{ pageTitle }}
         </h1>

--- a/src/views/personal/personal-email-check.njk
+++ b/src/views/personal/personal-email-check.njk
@@ -1,0 +1,50 @@
+{% extends 'common/layout.njk' %}
+
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "common/navigation/back-sign-out-link.njk" import appBackSignOutLink with context %}
+
+{% block beforeContent %}
+  {{ appBackSignOutLink({ backLink: backLink, href: backLink.href }) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post" novalidate>
+        <input type="hidden" name="crumb" value="{{ crumb }}">
+        <span class="govuk-caption-l text-wrap-no-hyphen">{{ userName }}</span>
+        <h1 class="govuk-heading-l">
+          {{ pageTitle }}
+        </h1>
+
+        {{ govukSummaryList({
+          rows: [
+            {
+              key: {
+                text: "Personal email address"
+              },
+              value: {
+                text: personalEmail
+              },
+              actions: {
+                items: [
+                  {
+                    href: changeLink,
+                    text: "Change",
+                    visuallyHiddenText: "personal email address",
+                    classes: "govuk-link--no-visited-state"
+                  }
+                ]
+              }
+            }
+          ]
+        }) }}
+
+        {{ govukButton({ text: "Submit", preventDoubleClick: true }) }}
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/test/unit/presenters/personal/personal-details-presenter.test.js
+++ b/test/unit/presenters/personal/personal-details-presenter.test.js
@@ -2,16 +2,16 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest'
 
 // Thing under test
-import { personalDetailsPresenter } from '../../../src/presenters/personal-details-presenter.js'
+import { personalDetailsPresenter } from '../../../../src/presenters/personal/personal-details-presenter.js'
 
 // Mock data
-import { getMappedData } from '../../mocks/mock-personal-details.js'
+import { getMappedData } from '../../../mocks/mock-personal-details.js'
 
 // Mock dependencies
-import { config } from '../../../src/config/index.js'
+import { config } from '../../../../src/config/index.js'
 
 // Mock imports
-vi.mock('../../../src/config/index.js', () => ({
+vi.mock('../../../../src/config/index.js', () => ({
   config: {
     get: vi.fn()
   }

--- a/test/unit/presenters/personal/personal-email-change-presenter.test.js
+++ b/test/unit/presenters/personal/personal-email-change-presenter.test.js
@@ -1,0 +1,98 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach } from 'vitest'
+
+// Thing under test
+import { personalEmailChangePresenter } from '../../../../src/presenters/personal/personal-email-change-presenter.js'
+
+describe('personalEmailChangePresenter', () => {
+  let data
+  let payload
+  const crn = '1234567890'
+
+  beforeEach(() => {
+    data = {
+      info: {
+        userName: 'John Doe',
+        fullName: {
+          first: 'John',
+          last: 'Doe'
+        }
+      },
+      contact: {
+        email: 'test@test.com'
+      }
+    }
+  })
+
+  describe('when provided with personal email change data', () => {
+    test('it correctly presents the data', () => {
+      const result = personalEmailChangePresenter(data, undefined, crn)
+
+      expect(result).toEqual({
+        backLink: { href: '/customer/1234567890/details' },
+        pageTitle: 'What is your personal email address?',
+        metaDescription: 'Update the email address for your personal account.',
+        userName: 'John Doe',
+        personalEmail: 'test@test.com'
+      })
+    })
+  })
+
+  describe('the "userName" property', () => {
+    describe('when the userName property is missing', () => {
+      beforeEach(() => {
+        delete data.info.userName
+      })
+
+      test('it should return userName as null', () => {
+        const result = personalEmailChangePresenter(data, undefined, crn)
+
+        expect(result.userName).toEqual(null)
+      })
+    })
+  })
+
+  describe('the "personalEmail" property', () => {
+    describe('when provided with a changed personal email', () => {
+      beforeEach(() => {
+        data.changePersonalEmail = 'new-email@test.com'
+      })
+
+      test('it should return the changed personal email as the personalEmail', () => {
+        const result = personalEmailChangePresenter(data, undefined, crn)
+
+        expect(result.personalEmail).toEqual('new-email@test.com')
+      })
+    })
+
+    describe('when provided with a payload', () => {
+      beforeEach(() => {
+        payload = 'even-newer-email@test.com'
+      })
+
+      test('it should return the payload as the personalEmail', () => {
+        const result = personalEmailChangePresenter(data, payload, crn)
+
+        expect(result.personalEmail).toEqual('even-newer-email@test.com')
+      })
+    })
+  })
+
+  describe('the "backLink" property', () => {
+    describe('when a crn is provided', () => {
+      test('it should link to the customer details page', () => {
+        const result = personalEmailChangePresenter(data, undefined, crn)
+
+        expect(result.backLink).toEqual({ href: '/customer/1234567890/details' })
+      })
+    })
+
+    describe('when a crn is not provided', () => {
+      test('it should link to the search-crn page', () => {
+        const result = personalEmailChangePresenter(data, undefined, undefined)
+
+        expect(result.backLink).toEqual({ href: '/search-crn' })
+      })
+    })
+  })
+})

--- a/test/unit/presenters/personal/personal-email-check-presenter.test.js
+++ b/test/unit/presenters/personal/personal-email-check-presenter.test.js
@@ -1,0 +1,68 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach } from 'vitest'
+
+// Thing under test
+import { personalEmailCheckPresenter } from '../../../../src/presenters/personal/personal-email-check-presenter.js'
+
+describe('personalEmailCheckPresenter', () => {
+  let data
+  const crn = '1234567890'
+
+  beforeEach(() => {
+    data = {
+      info: {
+        userName: 'John Doe',
+        fullName: {
+          first: 'John',
+          last: 'Doe'
+        }
+      },
+      contact: {
+        email: 'test@test.com'
+      }
+    }
+  })
+
+  describe('when provided with personal email check data', () => {
+    test('it correctly presents the data', () => {
+      const result = personalEmailCheckPresenter(data, crn)
+
+      expect(result).toEqual({
+        backLink: { href: '/customer/1234567890/account-email-change' },
+        changeLink: '/customer/1234567890/account-email-change',
+        pageTitle: 'Check your personal email address is correct before submitting',
+        metaDescription: 'Check the email address for your personal account is correct.',
+        userName: 'John Doe',
+        personalEmail: 'test@test.com'
+      })
+    })
+  })
+
+  describe('the "userName" property', () => {
+    describe('when the userName property is missing', () => {
+      beforeEach(() => {
+        delete data.info.userName
+      })
+
+      test('it should return userName as null', () => {
+        const result = personalEmailCheckPresenter(data, crn)
+
+        expect(result.userName).toEqual(null)
+      })
+    })
+  })
+
+  describe('the "personalEmail" property', () => {
+    describe('when provided with a changed personal email', () => {
+      beforeEach(() => {
+        data.changePersonalEmail = 'new-email@new-email.com'
+      })
+
+      test('it should return the changed personal email as the personalEmail', () => {
+        const result = personalEmailCheckPresenter(data, crn)
+
+        expect(result.personalEmail).toEqual('new-email@new-email.com')
+      })
+    })
+  })
+})

--- a/test/unit/routes/customer/customer-details-routes.test.js
+++ b/test/unit/routes/customer/customer-details-routes.test.js
@@ -4,7 +4,7 @@ import { describe, test, expect, vi, beforeEach } from 'vitest'
 // Mocks
 import { fetchPersonalDetailsService } from '../../../../src/services/fetch-personal-details-service.js'
 import { validatePersonalDetailsService } from '../../../../src/services/personal/validate-personal-details-service.js'
-import { personalDetailsPresenter } from '../../../../src/presenters/personal-details-presenter.js'
+import { personalDetailsPresenter } from '../../../../src/presenters/personal/personal-details-presenter.js'
 
 // Thing under test
 import { customerDetailsRoutes } from '../../../../src/routes/customer/customer-details-routes.js'
@@ -16,7 +16,7 @@ vi.mock('../../../../src/services/fetch-personal-details-service.js', () => ({
   fetchPersonalDetailsService: vi.fn()
 }))
 
-vi.mock('../../../../src/presenters/personal-details-presenter.js', () => ({
+vi.mock('../../../../src/presenters/personal/personal-details-presenter.js', () => ({
   personalDetailsPresenter: vi.fn()
 }))
 

--- a/test/unit/routes/customer/personal-email-change-routes.test.js
+++ b/test/unit/routes/customer/personal-email-change-routes.test.js
@@ -1,0 +1,192 @@
+// Test framework dependencies
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+// Things we need to mock
+import { setSessionData } from '../../../../src/utils/session/set-session-data.js'
+import { fetchPersonalChangeService } from '../../../../src/services/personal/fetch-personal-change-service.js'
+
+// Thing under test
+import { personalEmailChangeRoutes } from '../../../../src/routes/customer/personal-email-change-routes.js'
+const [getPersonalEmailChange, postPersonalEmailChange] = personalEmailChangeRoutes
+
+// Mocks
+vi.mock('../../../../src/utils/session/set-session-data.js', () => ({
+  setSessionData: vi.fn()
+}))
+
+vi.mock('../../../../src/services/personal/fetch-personal-change-service.js', () => ({
+  fetchPersonalChangeService: vi.fn()
+}))
+
+describe('personal email change', () => {
+  let request
+  let h
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    request = {
+      params: { crn: '1234567890' },
+      auth: { credentials: { email: 'test@example.com' } },
+      yar: {},
+      payload: {}
+    }
+
+    const responseStub = {
+      code: vi.fn().mockReturnThis(),
+      takeover: vi.fn().mockReturnThis()
+    }
+
+    h = {
+      redirect: vi.fn(),
+      view: vi.fn(() => responseStub)
+    }
+  })
+
+  describe('GET /customer/{crn}/account-email-change', () => {
+    describe('when a request is valid', () => {
+      beforeEach(() => {
+        fetchPersonalChangeService.mockResolvedValue(getMockData())
+      })
+
+      test('should have the correct method and path configured', () => {
+        expect(getPersonalEmailChange.method).toBe('GET')
+        expect(getPersonalEmailChange.path).toBe('/customer/{crn}/account-email-change')
+      })
+
+      test('it calls fetchPersonalChangeService', async () => {
+        await getPersonalEmailChange.handler(request, h)
+
+        expect(fetchPersonalChangeService).toHaveBeenCalledWith(request.yar, '1234567890', 'test@example.com', 'changePersonalEmail')
+      })
+
+      test('should render personal-email-change view with page data', async () => {
+        await getPersonalEmailChange.handler(request, h)
+
+        expect(h.view).toHaveBeenCalledWith('personal/personal-email-change', getPageData())
+      })
+    })
+
+    describe('when the crn fails validation', () => {
+      beforeEach(() => {
+        request.params.crn = 'invalid-crn'
+      })
+
+      test('it redirects to the search-crn page and does not fetch data', async () => {
+        await getPersonalEmailChange.handler(request, h)
+
+        expect(h.redirect).toHaveBeenCalledWith('/search-crn')
+        expect(fetchPersonalChangeService).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('POST /customer/{crn}/account-email-change', () => {
+    beforeEach(() => {
+      request.payload = { personalEmail: 'new-email@test.com' }
+
+      fetchPersonalChangeService.mockResolvedValue({ ...getMockData(), changePersonalEmail: request.payload.personalEmail })
+    })
+
+    test('should have the correct method and path configured', () => {
+      expect(postPersonalEmailChange.method).toBe('POST')
+      expect(postPersonalEmailChange.path).toBe('/customer/{crn}/account-email-change')
+    })
+
+    describe('and the validation passes', () => {
+      test('it sets the session data and redirects to the check page', async () => {
+        await postPersonalEmailChange.options.handler(request, h)
+
+        expect(setSessionData).toHaveBeenCalledWith(
+          request.yar,
+          'personalDetailsUpdate',
+          'changePersonalEmail',
+          request.payload.personalEmail
+        )
+        expect(h.redirect).toHaveBeenCalledWith('/customer/1234567890/account-email-check')
+      })
+    })
+
+    describe('and the validation fails', () => {
+      let err
+
+      beforeEach(() => {
+        err = {
+          details: [
+            {
+              message: 'Enter a personal email address',
+              path: ['personalEmail'],
+              type: 'string.empty'
+            }
+          ]
+        }
+      })
+
+      test('it fetches the personal details', async () => {
+        await postPersonalEmailChange.options.validate.failAction(request, h, err)
+
+        expect(fetchPersonalChangeService).toHaveBeenCalledWith(
+          request.yar,
+          '1234567890',
+          'test@example.com',
+          'changePersonalEmail'
+        )
+      })
+
+      test('it returns the page successfully with the error summary banner', async () => {
+        await postPersonalEmailChange.options.validate.failAction(request, h, err)
+
+        expect(h.view).toHaveBeenCalledWith('personal/personal-email-change', getPageDataError())
+      })
+
+      test('it should handle undefined errors', async () => {
+        await postPersonalEmailChange.options.validate.failAction(request, h, [])
+
+        const pageData = getPageDataError()
+        pageData.errors = {}
+
+        expect(h.view).toHaveBeenCalledWith('personal/personal-email-change', pageData)
+      })
+    })
+  })
+})
+
+const getMockData = () => {
+  return {
+    info: {
+      userName: 'John Doe',
+      fullName: {
+        first: 'John',
+        last: 'Doe'
+      }
+    },
+    contact: {
+      email: 'new-email@test.com'
+    }
+  }
+}
+
+const getPageData = () => {
+  return {
+    backLink: { href: '/customer/1234567890/details' },
+    pageTitle: 'What is your personal email address?',
+    metaDescription: 'Update the email address for your personal account.',
+    userName: 'John Doe',
+    personalEmail: 'new-email@test.com'
+  }
+}
+
+const getPageDataError = () => {
+  return {
+    backLink: { href: '/customer/1234567890/details' },
+    pageTitle: 'What is your personal email address?',
+    metaDescription: 'Update the email address for your personal account.',
+    userName: 'John Doe',
+    personalEmail: 'new-email@test.com',
+    errors: {
+      personalEmail: {
+        text: 'Enter a personal email address'
+      }
+    }
+  }
+}

--- a/test/unit/routes/customer/personal-email-check-routes.test.js
+++ b/test/unit/routes/customer/personal-email-check-routes.test.js
@@ -1,0 +1,133 @@
+// Test framework dependencies
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+// Things we need to mock
+import { fetchPersonalChangeService } from '../../../../src/services/personal/fetch-personal-change-service.js'
+import { updatePersonalEmailChangeService } from '../../../../src/services/personal/update-personal-email-change-service.js'
+
+// Thing under test
+import { personalEmailCheckRoutes } from '../../../../src/routes/customer/personal-email-check-routes.js'
+const [getPersonalEmailCheck, postPersonalEmailCheck] = personalEmailCheckRoutes
+
+// Mocks
+vi.mock('../../../../src/services/personal/fetch-personal-change-service.js', () => ({
+  fetchPersonalChangeService: vi.fn()
+}))
+
+vi.mock('../../../../src/services/personal/update-personal-email-change-service.js', () => ({
+  updatePersonalEmailChangeService: vi.fn()
+}))
+
+describe('personal email check', () => {
+  let request
+  let h
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    request = {
+      params: { crn: '1234567890' },
+      auth: { credentials: { email: 'test@example.com' } },
+      yar: {}
+    }
+  })
+
+  describe('GET /customer/{crn}/account-email-check', () => {
+    describe('when a request is valid', () => {
+      beforeEach(() => {
+        h = {
+          view: vi.fn().mockReturnValue({}),
+          redirect: vi.fn()
+        }
+
+        fetchPersonalChangeService.mockResolvedValue(getMockData())
+      })
+
+      test('should have the correct method and path configured', () => {
+        expect(getPersonalEmailCheck.method).toBe('GET')
+        expect(getPersonalEmailCheck.path).toBe('/customer/{crn}/account-email-check')
+      })
+
+      test('it fetches the data from the session', async () => {
+        await getPersonalEmailCheck.handler(request, h)
+
+        expect(fetchPersonalChangeService).toHaveBeenCalledWith(request.yar, '1234567890', 'test@example.com', 'changePersonalEmail')
+      })
+
+      test('should render personal-email-check view with page data', async () => {
+        await getPersonalEmailCheck.handler(request, h)
+
+        expect(h.view).toHaveBeenCalledWith('personal/personal-email-check', getPageData())
+      })
+    })
+
+    describe('when the crn fails validation', () => {
+      beforeEach(() => {
+        h = {
+          view: vi.fn(),
+          redirect: vi.fn().mockReturnValue({})
+        }
+
+        request.params.crn = 'invalid-crn'
+      })
+
+      test('it redirects to the search-crn page and does not fetch data', async () => {
+        await getPersonalEmailCheck.handler(request, h)
+
+        expect(h.redirect).toHaveBeenCalledWith('/search-crn')
+        expect(fetchPersonalChangeService).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('POST /customer/{crn}/account-email-check', () => {
+    beforeEach(() => {
+      h = {
+        redirect: vi.fn(() => h)
+      }
+    })
+
+    test('should have the correct method and path configured', () => {
+      expect(postPersonalEmailCheck.method).toBe('POST')
+      expect(postPersonalEmailCheck.path).toBe('/customer/{crn}/account-email-check')
+    })
+
+    test('it calls updatePersonalEmailChangeService with yar, crn and email', async () => {
+      await postPersonalEmailCheck.handler(request, h)
+
+      expect(updatePersonalEmailChangeService).toHaveBeenCalledWith(request.yar, '1234567890', 'test@example.com')
+    })
+
+    test('it redirects to the customer details page', async () => {
+      await postPersonalEmailCheck.handler(request, h)
+
+      expect(h.redirect).toHaveBeenCalledWith('/customer/1234567890/details')
+    })
+  })
+})
+
+const getMockData = () => {
+  return {
+    info: {
+      userName: 'John Doe',
+      fullName: {
+        first: 'John',
+        last: 'Doe'
+      }
+    },
+    contact: {
+      email: 'test@example.com'
+    }
+  }
+}
+
+const getPageData = () => {
+  return {
+    backLink: { href: '/customer/1234567890/account-email-change' },
+    changeLink: '/customer/1234567890/account-email-change',
+    pageTitle: 'Check your personal email address is correct before submitting',
+    metaDescription: 'Check the email address for your personal account is correct.',
+    userName: 'John Doe',
+    personalEmail: 'test@example.com'
+  }
+}

--- a/test/unit/services/personal/update-personal-email-change-service.test.js
+++ b/test/unit/services/personal/update-personal-email-change-service.test.js
@@ -1,0 +1,109 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+// Things we need to mock
+import { mutations } from '@defra/fcp-sfd-frontend-engine'
+import { fetchPersonalChangeService } from '../../../../src/services/personal/fetch-personal-change-service.js'
+import { flashNotification } from '../../../../src/utils/notifications/flash-notification.js'
+import { updateDalService } from '../../../../src/services/DAL/update-dal-service.js'
+
+// Thing under test
+import { updatePersonalEmailChangeService } from '../../../../src/services/personal/update-personal-email-change-service.js'
+
+// Mocks
+vi.mock('../../../../src/services/personal/fetch-personal-change-service.js', () => ({
+  fetchPersonalChangeService: vi.fn()
+}))
+
+vi.mock('../../../../src/utils/notifications/flash-notification.js', () => ({
+  flashNotification: vi.fn()
+}))
+
+vi.mock('../../../../src/services/DAL/update-dal-service.js', () => ({
+  updateDalService: vi.fn().mockResolvedValue({})
+}))
+
+describe('updatePersonalEmailChangeService', () => {
+  let yar
+  let crn
+  let email
+  let data
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    crn = '1234567890'
+    email = 'test@example.com'
+
+    data = {
+      crn,
+      info: {
+        userName: 'John Doe',
+        fullName: { first: 'John', last: 'Doe' }
+      },
+      contact: { email: 'old-email@test.com' },
+      changePersonalEmail: 'new-email@test.com'
+    }
+
+    fetchPersonalChangeService.mockResolvedValue(data)
+
+    yar = { clear: vi.fn() }
+  })
+
+  describe('when called', () => {
+    test('it fetches the personal details with the crn and email', async () => {
+      await updatePersonalEmailChangeService(yar, crn, email)
+
+      expect(fetchPersonalChangeService).toHaveBeenCalledWith(yar, crn, email, 'changePersonalEmail')
+    })
+
+    test('it calls updateDalService with the correct mutation and variables', async () => {
+      await updatePersonalEmailChangeService(yar, crn, email)
+
+      expect(updateDalService).toHaveBeenCalledWith(mutations.updateCustomerEmail, {
+        input: {
+          email: {
+            address: 'new-email@test.com'
+          },
+          crn
+        }
+      }, email)
+    })
+
+    test('it clears the personalDetailsUpdate from session', async () => {
+      await updatePersonalEmailChangeService(yar, crn, email)
+
+      expect(yar.clear).toHaveBeenCalledWith('personalDetailsUpdate')
+    })
+
+    test('adds a flash notification confirming the change in data', async () => {
+      await updatePersonalEmailChangeService(yar, crn, email)
+
+      expect(flashNotification).toHaveBeenCalledWith(yar, 'Success', 'You have updated your personal email address')
+    })
+  })
+
+  describe('when there is no changePersonalEmail in session data', () => {
+    beforeEach(() => {
+      data.changePersonalEmail = undefined
+    })
+
+    test('it returns early and does not call updateDalService', async () => {
+      await updatePersonalEmailChangeService(yar, crn, email)
+
+      expect(updateDalService).not.toHaveBeenCalled()
+    })
+
+    test('it does not add a flash notification', async () => {
+      await updatePersonalEmailChangeService(yar, crn, email)
+
+      expect(flashNotification).not.toHaveBeenCalled()
+    })
+
+    test('it does not clear personalDetailsUpdate from session', async () => {
+      await updatePersonalEmailChangeService(yar, crn, email)
+
+      expect(yar.clear).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FLS2-57

## Summary

Recreates the personal email change/check journey in the internal service, matching the existing external journey. Staff can view and update a customer's personal email address (add when none is on file, or change an existing one), review it on a check page, and submit. The DAL write reuses the shared `updateCustomerEmail` mutation from the engine.

## Changes

- Add GET/POST routes for `/customer/{crn}/account-email-change` and `/customer/{crn}/account-email-check`.
- Add `personalEmailChangePresenter` and `personalEmailCheckPresenter`, kept local to this service.
- Add `updatePersonalEmailChangeService`, which calls the shared `mutations.updateCustomerEmail` via `updateDalService`, clears the session draft, and sets the success banner.
- Add the change and check Nunjucks views.
- Register the new routes and reorganize the personal-details presenter into `presenters/personal/`.
- Validation reuses the shared `schemas.personal.email`; error messages match the acceptance criteria.

## Notes

- Depends on engine `0.12.0` (FLS2-57 engine PR); the `@defra/fcp-sfd-frontend-engine` dependency must be bumped from `0.10.0` to `0.12.0` after the engine release.
- RBAC is not yet applied (deferred) — assumes an authenticated staff user with write permission.
