### PR TITLE
Move Error: page title prefix into layout.njk

### DIFF
--- a/src/views/business/business-email-change.njk
+++ b/src/views/business/business-email-change.njk
@@ -5,8 +5,6 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "common/navigation/back-sign-out-link.njk" import appBackSignOutLink with context %}
 
-{% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} | {{ serviceName }}{% endblock %}
-
 {% block beforeContent %}
   {{ appBackSignOutLink(backLink)}}
 {% endblock %}

--- a/src/views/common/layout.njk
+++ b/src/views/common/layout.njk
@@ -41,11 +41,11 @@
 {% endblock %}
 
 {% block pageTitle %}
-    {% if pageTitle %}
-    {{ pageTitle }} | {{ serviceName }}
-  {% else %}
-    {{ serviceName }}
-  {% endif %}
+  {%- if pageTitle -%}
+    {{ "Error: " if errors }}{{ pageTitle }} | {{ serviceName }}
+  {%- else -%}
+    {{ "Error: " if errors }}{{ serviceName }}
+  {%- endif -%}
 {% endblock %}
 
 {% block content %}{% endblock %}

--- a/test/integration/narrow/views/layout-error-title.test.js
+++ b/test/integration/narrow/views/layout-error-title.test.js
@@ -1,0 +1,73 @@
+import { constants } from 'node:http2'
+import { beforeAll, afterAll, describe, test, expect } from 'vitest'
+import '../../../mocks/setup-server-mocks.js'
+
+const { HTTP_STATUS_OK, HTTP_STATUS_BAD_REQUEST } = constants
+
+const { createServer } = await import('../../../../src/server.js')
+
+describe('Error: page title prefix (layout.njk)', () => {
+  const path = '/search-sbi'
+  const credentials = { sessionId: 'session-id', scope: [] }
+  let server
+
+  beforeAll(async () => {
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    if (server) {
+      await server.stop()
+    }
+  })
+
+  // The crumb (CSRF) cookie is issued on a GET and must be echoed back on the POST.
+  const getCrumb = async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: path,
+      auth: { strategy: 'session', credentials }
+    })
+
+    const setCookies = [].concat(response.headers['set-cookie'] ?? [])
+    const crumbCookie = setCookies.find((cookie) => cookie.startsWith('crumb='))
+    const crumbValue = crumbCookie.split(';')[0].split('=')[1]
+
+    return { crumbValue, cookie: `crumb=${crumbValue}` }
+  }
+
+  describe('when the page renders with validation errors', () => {
+    test('it prefixes the page title with "Error: "', async () => {
+      const { crumbValue, cookie } = await getCrumb()
+
+      const response = await server.inject({
+        method: 'POST',
+        url: path,
+        auth: { strategy: 'session', credentials },
+        headers: { cookie },
+        payload: { sbi: 'not-a-valid-sbi', crumb: crumbValue }
+      })
+
+      const title = response.payload.match(/<title>([\s\S]*?)<\/title>/)[1].trim()
+
+      expect(response.statusCode).toBe(HTTP_STATUS_BAD_REQUEST)
+      expect(title.startsWith('Error: ')).toBe(true)
+    })
+  })
+
+  describe('when the page renders without validation errors', () => {
+    test('it does not prefix the page title with "Error: "', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: path,
+        auth: { strategy: 'session', credentials }
+      })
+
+      const title = response.payload.match(/<title>([\s\S]*?)<\/title>/)[1].trim()
+
+      expect(response.statusCode).toBe(HTTP_STATUS_OK)
+      expect(title.startsWith('Error: ')).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Why

Follow-up to #134. In that PR, @thousand-leaves noted ([comment](https://github.com/DEFRA/fcp-sfd-frontend-internal/pull/134#discussion_r3644692042)) that prefixing the page `<title>` with `Error:` on validation failure (the GDS [Validation pattern](https://design-system.service.gov.uk/patterns/validation/)) is a good addition we did not have anywhere else, and suggested moving it into `layout.njk` so every page benefits, "as a new pr of course".

## What

- Add the `Error:` title prefix to the shared `{% block pageTitle %}` in `src/views/common/layout.njk`, driven by the existing `errors` view-context variable, with `{%- -%}` whitespace trimming.
- Remove the now-redundant per-page `pageTitle` override on `src/views/business/business-email-change.njk`; the behaviour now comes solely from the layout, so all pages pick it up automatically on a validation failure.
- Add a narrow integration test (`test/integration/narrow/views/layout-error-title.test.js`) that asserts the `<title>` is prefixed with `Error:` on an error render and is not prefixed on a clean render.

## Testing

- New integration test passes.
- `npm run lint` clean for the changed files (pre-existing SCSS lint issues are unrelated and untouched).

Closes the follow-up raised in #134.