### PR TITLE
FLS2-56: Add Personal Phone Numbers Change Journey

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "license": "OGL-UK-3.0",
   "dependencies": {
-    "@defra/fcp-sfd-frontend-engine": "0.13.0",
+    "@defra/fcp-sfd-frontend-engine": "0.12.0",
     "@defra/hapi-tracing": "1.30.0",
     "@elastic/ecs-pino-format": "1.5.0",
     "@hapi/bell": "13.1.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "license": "OGL-UK-3.0",
   "dependencies": {
-    "@defra/fcp-sfd-frontend-engine": "0.12.0",
+    "@defra/fcp-sfd-frontend-engine": "0.13.0",
     "@defra/hapi-tracing": "1.30.0",
     "@elastic/ecs-pino-format": "1.5.0",
     "@hapi/bell": "13.1.0",

--- a/src/presenters/personal/personal-phone-numbers-change-presenter.js
+++ b/src/presenters/personal/personal-phone-numbers-change-presenter.js
@@ -1,0 +1,29 @@
+import { presenters } from '@defra/fcp-sfd-frontend-engine'
+
+/*
+ * Formats data ready for presenting in the `/customer/{CRN}/account-phone-numbers-change` page
+ * @module personalPhoneNumbersChangePresenter
+ */
+
+const personalPhoneNumbersChangePresenter = (personalDetails, payload, crn) => {
+  return {
+    backLink: { href: crn ? `/customer/${crn}/details` : '/search-crn' },
+    pageTitle: 'What are your personal phone numbers?',
+    metaDescription: 'Update the phone numbers for your personal account.',
+    userName: personalDetails.info.userName ?? null,
+    personalTelephone: presenters.formatNumber(
+      payload?.personalTelephone,
+      personalDetails.changePersonalPhoneNumbers?.personalTelephone,
+      personalDetails.contact.telephone
+    ),
+    personalMobile: presenters.formatNumber(
+      payload?.personalMobile,
+      personalDetails.changePersonalPhoneNumbers?.personalMobile,
+      personalDetails.contact.mobile
+    )
+  }
+}
+
+export {
+  personalPhoneNumbersChangePresenter
+}

--- a/src/presenters/personal/personal-phone-numbers-check-presenter.js
+++ b/src/presenters/personal/personal-phone-numbers-check-presenter.js
@@ -4,6 +4,13 @@
  */
 
 const personalPhoneNumbersCheckPresenter = (personalDetails, crn) => {
+  // Fall back to the saved phone numbers when there is no pending change in the session (for
+  // example when the user reaches this page via the browser back button after submitting).
+  const phoneNumbers = personalDetails.changePersonalPhoneNumbers ?? {
+    personalTelephone: personalDetails.contact.telephone,
+    personalMobile: personalDetails.contact.mobile
+  }
+
   return {
     backLink: { href: `/customer/${crn}/account-phone-numbers-change` },
     changeLink: `/customer/${crn}/account-phone-numbers-change`,
@@ -11,8 +18,8 @@ const personalPhoneNumbersCheckPresenter = (personalDetails, crn) => {
     metaDescription: 'Check the phone numbers for your personal account are correct.',
     userName: personalDetails.info.userName ?? null,
     personalTelephone: {
-      telephone: personalDetails.changePersonalPhoneNumbers.personalTelephone ?? null,
-      mobile: personalDetails.changePersonalPhoneNumbers.personalMobile ?? null
+      telephone: phoneNumbers.personalTelephone ?? null,
+      mobile: phoneNumbers.personalMobile ?? null
     }
   }
 }

--- a/src/presenters/personal/personal-phone-numbers-check-presenter.js
+++ b/src/presenters/personal/personal-phone-numbers-check-presenter.js
@@ -4,8 +4,6 @@
  */
 
 const personalPhoneNumbersCheckPresenter = (personalDetails, crn) => {
-  // Fall back to the saved phone numbers when there is no pending change in the session (for
-  // example when the user reaches this page via the browser back button after submitting).
   const phoneNumbers = personalDetails.changePersonalPhoneNumbers ?? {
     personalTelephone: personalDetails.contact.telephone,
     personalMobile: personalDetails.contact.mobile

--- a/src/presenters/personal/personal-phone-numbers-check-presenter.js
+++ b/src/presenters/personal/personal-phone-numbers-check-presenter.js
@@ -1,0 +1,22 @@
+/**
+ * Formats data ready for presenting in the `/customer/{CRN}/account-phone-numbers-check` page
+ * @module personalPhoneNumbersCheckPresenter
+ */
+
+const personalPhoneNumbersCheckPresenter = (personalDetails, crn) => {
+  return {
+    backLink: { href: `/customer/${crn}/account-phone-numbers-change` },
+    changeLink: `/customer/${crn}/account-phone-numbers-change`,
+    pageTitle: 'Check your personal phone numbers are correct before submitting',
+    metaDescription: 'Check the phone numbers for your personal account are correct.',
+    userName: personalDetails.info.userName ?? null,
+    personalTelephone: {
+      telephone: personalDetails.changePersonalPhoneNumbers.personalTelephone ?? null,
+      mobile: personalDetails.changePersonalPhoneNumbers.personalMobile ?? null
+    }
+  }
+}
+
+export {
+  personalPhoneNumbersCheckPresenter
+}

--- a/src/routes/customer/personal-phone-numbers-change-routes.js
+++ b/src/routes/customer/personal-phone-numbers-change-routes.js
@@ -1,0 +1,66 @@
+import { schemas, utils, constants } from '@defra/fcp-sfd-frontend-engine'
+
+import { personalPhoneNumbersChangePresenter } from '../../presenters/personal/personal-phone-numbers-change-presenter.js'
+import { fetchPersonalChangeService } from '../../services/personal/fetch-personal-change-service.js'
+import { setSessionData } from '../../utils/session/set-session-data.js'
+
+const getPersonalPhoneNumbersChange = {
+  method: 'GET',
+  path: '/customer/{crn}/account-phone-numbers-change',
+  handler: async (request, h) => {
+    const { params, auth, yar } = request
+    const { crn } = params
+
+    const { error } = schemas.customer.crn.validate({ crn })
+
+    if (error) {
+      return h.redirect('/search-crn')
+    }
+
+    const email = auth.credentials?.email
+    const personalDetails = await fetchPersonalChangeService(yar, crn, email, 'changePersonalPhoneNumbers')
+    const pageData = personalPhoneNumbersChangePresenter(personalDetails, undefined, crn)
+
+    return h.view('personal/personal-phone-numbers-change', pageData)
+  }
+}
+
+const postPersonalPhoneNumbersChange = {
+  method: 'POST',
+  path: '/customer/{crn}/account-phone-numbers-change',
+  options: {
+    validate: {
+      payload: schemas.personal.phone,
+      options: { abortEarly: false },
+      failAction: async (request, h, err) => {
+        const { params, auth, yar, payload } = request
+        const { crn } = params
+
+        const email = auth.credentials?.email
+        const errors = utils.formatValidationErrors(err.details || [])
+        const personalDetails = await fetchPersonalChangeService(yar, crn, email, 'changePersonalPhoneNumbers')
+        const pageData = personalPhoneNumbersChangePresenter(personalDetails, payload, crn)
+
+        return h.view('personal/personal-phone-numbers-change', { ...pageData, errors }).code(constants.statusCodes.BAD_REQUEST).takeover()
+      }
+    },
+    handler: async (request, h) => {
+      const { params, yar, payload } = request
+      const { crn } = params
+
+      const phoneNumbers = {
+        personalTelephone: payload.personalTelephone ?? null,
+        personalMobile: payload.personalMobile ?? null
+      }
+
+      setSessionData(yar, 'personalDetailsUpdate', 'changePersonalPhoneNumbers', phoneNumbers)
+
+      return h.redirect(`/customer/${crn}/account-phone-numbers-check`)
+    }
+  }
+}
+
+export const personalPhoneNumbersChangeRoutes = [
+  getPersonalPhoneNumbersChange,
+  postPersonalPhoneNumbersChange
+]

--- a/src/routes/customer/personal-phone-numbers-check-routes.js
+++ b/src/routes/customer/personal-phone-numbers-check-routes.js
@@ -1,0 +1,45 @@
+import { schemas } from '@defra/fcp-sfd-frontend-engine'
+
+import { personalPhoneNumbersCheckPresenter } from '../../presenters/personal/personal-phone-numbers-check-presenter.js'
+import { fetchPersonalChangeService } from '../../services/personal/fetch-personal-change-service.js'
+import { updatePersonalPhoneNumbersChangeService } from '../../services/personal/update-personal-phone-numbers-change-service.js'
+
+const getPersonalPhoneNumbersCheck = {
+  method: 'GET',
+  path: '/customer/{crn}/account-phone-numbers-check',
+  handler: async (request, h) => {
+    const { params, auth, yar } = request
+    const { crn } = params
+
+    const { error } = schemas.customer.crn.validate({ crn })
+
+    if (error) {
+      return h.redirect('/search-crn')
+    }
+
+    const email = auth.credentials?.email
+    const personalDetails = await fetchPersonalChangeService(yar, crn, email, 'changePersonalPhoneNumbers')
+    const pageData = personalPhoneNumbersCheckPresenter(personalDetails, crn)
+
+    return h.view('personal/personal-phone-numbers-check', pageData)
+  }
+}
+
+const postPersonalPhoneNumbersCheck = {
+  method: 'POST',
+  path: '/customer/{crn}/account-phone-numbers-check',
+  handler: async (request, h) => {
+    const { params, auth, yar } = request
+    const { crn } = params
+
+    const email = auth.credentials?.email
+    await updatePersonalPhoneNumbersChangeService(yar, crn, email)
+
+    return h.redirect(`/customer/${crn}/details`)
+  }
+}
+
+export const personalPhoneNumbersCheckRoutes = [
+  getPersonalPhoneNumbersCheck,
+  postPersonalPhoneNumbersCheck
+]

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -16,6 +16,8 @@ import { personalNameChangeRoutes } from './customer/personal-name-change-routes
 import { personalNameCheckRoutes } from './customer/personal-name-check-routes.js'
 import { personalEmailChangeRoutes } from './customer/personal-email-change-routes.js'
 import { personalEmailCheckRoutes } from './customer/personal-email-check-routes.js'
+import { personalPhoneNumbersChangeRoutes } from './customer/personal-phone-numbers-change-routes.js'
+import { personalPhoneNumbersCheckRoutes } from './customer/personal-phone-numbers-check-routes.js'
 import { businessDetailsRoutes } from './business/business-details-routes.js'
 import { businessEmailChangeRoutes } from './business/business-email-change-routes.js'
 import { businessEmailCheckRoutes } from './business/business-email-check-routes.js'
@@ -39,6 +41,8 @@ export const routes = [
   ...personalNameCheckRoutes,
   ...personalEmailChangeRoutes,
   ...personalEmailCheckRoutes,
+  ...personalPhoneNumbersChangeRoutes,
+  ...personalPhoneNumbersCheckRoutes,
   ...businessDetailsRoutes,
   ...businessEmailChangeRoutes,
   ...businessEmailCheckRoutes

--- a/src/services/personal/update-personal-phone-numbers-change-service.js
+++ b/src/services/personal/update-personal-phone-numbers-change-service.js
@@ -1,0 +1,44 @@
+/**
+ * Service to update personal phone numbers (landline and mobile)
+ *
+ * Fetches the pending personal phone number changes from the session
+ * Calls the DAL to persist the updated phone numbers using updateDalService
+ * Clears the cached personal details data from the session
+ * Displays a success flash notification to the user
+ *
+ * @module updatePersonalPhoneNumbersChangeService
+ */
+
+import { mutations } from '@defra/fcp-sfd-frontend-engine'
+
+import { fetchPersonalChangeService } from './fetch-personal-change-service.js'
+import { flashNotification } from '../../utils/notifications/flash-notification.js'
+import { updateDalService } from '../DAL/update-dal-service.js'
+
+const updatePersonalPhoneNumbersChangeService = async (yar, crn, email) => {
+  const personalDetails = await fetchPersonalChangeService(yar, crn, email, 'changePersonalPhoneNumbers')
+
+  if (!personalDetails.changePersonalPhoneNumbers) {
+    return
+  }
+
+  const variables = {
+    input: {
+      phone: {
+        landline: personalDetails.changePersonalPhoneNumbers.personalTelephone ?? null,
+        mobile: personalDetails.changePersonalPhoneNumbers.personalMobile ?? null
+      },
+      crn: personalDetails.crn
+    }
+  }
+
+  await updateDalService(mutations.updateCustomerPhone, variables, email)
+
+  yar.clear('personalDetailsUpdate')
+
+  flashNotification(yar, 'Success', 'You have updated your personal phone numbers')
+}
+
+export {
+  updatePersonalPhoneNumbersChangeService
+}

--- a/src/views/personal/personal-phone-numbers-change.njk
+++ b/src/views/personal/personal-phone-numbers-change.njk
@@ -1,0 +1,72 @@
+{% extends 'common/layout.njk' %}
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "common/navigation/back-sign-out-link.njk" import appBackSignOutLink with context %}
+
+{% block beforeContent %}
+  {{ appBackSignOutLink({ backLink: backLink, href: backLink.href }) }}
+{% endblock %}
+
+{% block content %}
+  {% if errors %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: errors | toErrorList
+    }) }}
+  {% endif %}
+
+<div class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post" novalidate>
+        <input type="hidden" name="crumb" value="{{ crumb }}">
+
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading">
+              {{ pageTitle }}
+            </h1>
+          </legend>
+          <div class="govuk-hint">
+            Enter at least one phone number
+          </div>
+
+          {{ govukInput({
+            label: {
+              text: "Personal telephone number"
+            },
+            classes: "govuk-input--width-20",
+            type: "tel",
+            id: "personalTelephone",
+            name: "personalTelephone",
+            value: personalTelephone,
+            autocomplete: "personal-telephone",
+            errorMessage: errors.personalTelephone and {
+              text: errors.personalTelephone.text
+            }
+          }) }}
+
+          {{ govukInput({
+            label: {
+              text: "Personal mobile phone number"
+            },
+            classes: "govuk-input--width-20",
+            type: "tel",
+            id: "personalMobile",
+            name: "personalMobile",
+            value: personalMobile,
+            autocomplete: "personal-mobile",
+            errorMessage: errors.personalMobile and {
+              text: errors.personalMobile.text
+            }
+          }) }}
+        </fieldset>
+
+        {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/src/views/personal/personal-phone-numbers-change.njk
+++ b/src/views/personal/personal-phone-numbers-change.njk
@@ -23,13 +23,13 @@
       <form method="post" novalidate>
         <input type="hidden" name="crumb" value="{{ crumb }}">
 
-        <fieldset class="govuk-fieldset">
+        <fieldset class="govuk-fieldset" aria-describedby="account-phone-numbers-hint">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">
               {{ pageTitle }}
             </h1>
           </legend>
-          <div class="govuk-hint">
+          <div class="govuk-hint" id="account-phone-numbers-hint">
             Enter at least one phone number
           </div>
 
@@ -42,7 +42,7 @@
             id: "personalTelephone",
             name: "personalTelephone",
             value: personalTelephone,
-            autocomplete: "personal-telephone",
+            autocomplete: "off",
             errorMessage: errors.personalTelephone and {
               text: errors.personalTelephone.text
             }
@@ -57,7 +57,7 @@
             id: "personalMobile",
             name: "personalMobile",
             value: personalMobile,
-            autocomplete: "personal-mobile",
+            autocomplete: "off",
             errorMessage: errors.personalMobile and {
               text: errors.personalMobile.text
             }

--- a/src/views/personal/personal-phone-numbers-check.njk
+++ b/src/views/personal/personal-phone-numbers-check.njk
@@ -15,14 +15,14 @@
     {% if personalTelephone.telephone %}
       {{ personalTelephone.telephone }}
     {% else %}
-      <span class="govuk-hint">Not added</span>
+      <span class="govuk-hint display-inline">Not added</span>
     {% endif %}
     <br>
     Mobile:
     {% if personalTelephone.mobile %}
       {{ personalTelephone.mobile }}
     {% else %}
-      <span class="govuk-hint">Not added</span>
+      <span class="govuk-hint display-inline">Not added</span>
     {% endif %}
   </p>
 {% endset %}

--- a/src/views/personal/personal-phone-numbers-check.njk
+++ b/src/views/personal/personal-phone-numbers-check.njk
@@ -1,0 +1,66 @@
+{% extends 'common/layout.njk' %}
+
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "common/navigation/back-sign-out-link.njk" import appBackSignOutLink with context %}
+
+{% block beforeContent %}
+  {{ appBackSignOutLink({ backLink: backLink, href: backLink.href }) }}
+{% endblock %}
+
+{% block content %}
+{% set phoneNumbersHtml %}
+  <p class="govuk-body">
+    Telephone:
+    {% if personalTelephone.telephone %}
+      {{ personalTelephone.telephone }}
+    {% else %}
+      <span class="govuk-hint">Not added</span>
+    {% endif %}
+    <br>
+    Mobile:
+    {% if personalTelephone.mobile %}
+      {{ personalTelephone.mobile }}
+    {% else %}
+      <span class="govuk-hint">Not added</span>
+    {% endif %}
+  </p>
+{% endset %}
+<div class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post" novalidate>
+        <input type="hidden" name="crumb" value="{{ crumb }}">
+        <h1 class="govuk-heading-l">
+          {{ pageTitle }}
+        </h1>
+
+        {{ govukSummaryList({
+          rows: [
+            {
+              key: {
+                text: "Personal phone numbers"
+              },
+              value: {
+                html: phoneNumbersHtml
+              },
+              actions: {
+                items: [
+                  {
+                    href: changeLink,
+                    text: "Change",
+                    visuallyHiddenText: "personal phone numbers",
+                    classes: "govuk-link--no-visited-state"
+                  }
+                ]
+              }
+            }
+          ]
+        }) }}
+
+        {{ govukButton({ text: "Submit", preventDoubleClick: true }) }}
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/test/unit/presenters/personal/personal-phone-numbers-change-presenter.test.js
+++ b/test/unit/presenters/personal/personal-phone-numbers-change-presenter.test.js
@@ -1,0 +1,105 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach } from 'vitest'
+
+// Thing under test
+import { personalPhoneNumbersChangePresenter } from '../../../../src/presenters/personal/personal-phone-numbers-change-presenter.js'
+
+describe('personalPhoneNumbersChangePresenter', () => {
+  let data
+  const crn = '1234567890'
+
+  beforeEach(() => {
+    data = {
+      info: {
+        userName: 'John Doe',
+        fullName: {
+          first: 'John',
+          last: 'Doe'
+        }
+      },
+      contact: {
+        telephone: '01111111111',
+        mobile: '02222222222'
+      }
+    }
+  })
+
+  describe('when provided with personal phone numbers change data', () => {
+    test('it correctly presents the data', () => {
+      const result = personalPhoneNumbersChangePresenter(data, undefined, crn)
+
+      expect(result).toEqual({
+        backLink: { href: '/customer/1234567890/details' },
+        pageTitle: 'What are your personal phone numbers?',
+        metaDescription: 'Update the phone numbers for your personal account.',
+        userName: 'John Doe',
+        personalTelephone: '01111111111',
+        personalMobile: '02222222222'
+      })
+    })
+  })
+
+  describe('the "userName" property', () => {
+    describe('when the userName property is missing', () => {
+      beforeEach(() => {
+        delete data.info.userName
+      })
+
+      test('it should return userName as null', () => {
+        const result = personalPhoneNumbersChangePresenter(data, undefined, crn)
+
+        expect(result.userName).toEqual(null)
+      })
+    })
+  })
+
+  describe('the phone number properties', () => {
+    describe('when provided with changed phone numbers in the session', () => {
+      beforeEach(() => {
+        data.changePersonalPhoneNumbers = {
+          personalTelephone: '03333333333',
+          personalMobile: '04444444444'
+        }
+      })
+
+      test('it should return the changed phone numbers', () => {
+        const result = personalPhoneNumbersChangePresenter(data, undefined, crn)
+
+        expect(result.personalTelephone).toEqual('03333333333')
+        expect(result.personalMobile).toEqual('04444444444')
+      })
+    })
+
+    describe('when provided with a payload', () => {
+      test('it should return the payload phone numbers', () => {
+        const payload = {
+          personalTelephone: '05555555555',
+          personalMobile: '06666666666'
+        }
+
+        const result = personalPhoneNumbersChangePresenter(data, payload, crn)
+
+        expect(result.personalTelephone).toEqual('05555555555')
+        expect(result.personalMobile).toEqual('06666666666')
+      })
+    })
+  })
+
+  describe('the "backLink" property', () => {
+    describe('when a crn is provided', () => {
+      test('it should link to the customer details page', () => {
+        const result = personalPhoneNumbersChangePresenter(data, undefined, crn)
+
+        expect(result.backLink).toEqual({ href: '/customer/1234567890/details' })
+      })
+    })
+
+    describe('when a crn is not provided', () => {
+      test('it should link to the search-crn page', () => {
+        const result = personalPhoneNumbersChangePresenter(data, undefined, undefined)
+
+        expect(result.backLink).toEqual({ href: '/search-crn' })
+      })
+    })
+  })
+})

--- a/test/unit/presenters/personal/personal-phone-numbers-check-presenter.test.js
+++ b/test/unit/presenters/personal/personal-phone-numbers-check-presenter.test.js
@@ -1,0 +1,100 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach } from 'vitest'
+
+// Thing under test
+import { personalPhoneNumbersCheckPresenter } from '../../../../src/presenters/personal/personal-phone-numbers-check-presenter.js'
+
+describe('personalPhoneNumbersCheckPresenter', () => {
+  let data
+  const crn = '1234567890'
+
+  beforeEach(() => {
+    data = {
+      info: {
+        userName: 'John Doe',
+        fullName: {
+          first: 'John',
+          last: 'Doe'
+        }
+      },
+      contact: {
+        telephone: '01111111111',
+        mobile: '02222222222'
+      },
+      changePersonalPhoneNumbers: {
+        personalTelephone: '01234567890',
+        personalMobile: '07123456789'
+      }
+    }
+  })
+
+  describe('when provided with personal phone numbers change data', () => {
+    test('it correctly presents the data', () => {
+      const result = personalPhoneNumbersCheckPresenter(data, crn)
+
+      expect(result).toEqual({
+        backLink: { href: '/customer/1234567890/account-phone-numbers-change' },
+        changeLink: '/customer/1234567890/account-phone-numbers-change',
+        pageTitle: 'Check your personal phone numbers are correct before submitting',
+        metaDescription: 'Check the phone numbers for your personal account are correct.',
+        userName: 'John Doe',
+        personalTelephone: {
+          telephone: '01234567890',
+          mobile: '07123456789'
+        }
+      })
+    })
+  })
+
+  describe('the "userName" property', () => {
+    describe('when the userName property is missing', () => {
+      beforeEach(() => {
+        delete data.info.userName
+      })
+
+      test('it should return userName as null', () => {
+        const result = personalPhoneNumbersCheckPresenter(data, crn)
+
+        expect(result.userName).toEqual(null)
+      })
+    })
+  })
+
+  describe('the "personalTelephone" property', () => {
+    describe('when a phone number is not provided', () => {
+      beforeEach(() => {
+        data.changePersonalPhoneNumbers = {
+          personalTelephone: null,
+          personalMobile: '07123456789'
+        }
+      })
+
+      test('it should return the missing number as null', () => {
+        const result = personalPhoneNumbersCheckPresenter(data, crn)
+
+        expect(result.personalTelephone).toEqual({
+          telephone: null,
+          mobile: '07123456789'
+        })
+      })
+    })
+
+    describe('when the mobile number is not provided', () => {
+      beforeEach(() => {
+        data.changePersonalPhoneNumbers = {
+          personalTelephone: '01234567890',
+          personalMobile: null
+        }
+      })
+
+      test('it should return the missing number as null', () => {
+        const result = personalPhoneNumbersCheckPresenter(data, crn)
+
+        expect(result.personalTelephone).toEqual({
+          telephone: '01234567890',
+          mobile: null
+        })
+      })
+    })
+  })
+})

--- a/test/unit/presenters/personal/personal-phone-numbers-check-presenter.test.js
+++ b/test/unit/presenters/personal/personal-phone-numbers-check-presenter.test.js
@@ -97,4 +97,19 @@ describe('personalPhoneNumbersCheckPresenter', () => {
       })
     })
   })
+
+  describe('when there is no pending change in the session', () => {
+    beforeEach(() => {
+      delete data.changePersonalPhoneNumbers
+    })
+
+    test('it falls back to the saved phone numbers', () => {
+      const result = personalPhoneNumbersCheckPresenter(data, crn)
+
+      expect(result.personalTelephone).toEqual({
+        telephone: '01111111111',
+        mobile: '02222222222'
+      })
+    })
+  })
 })

--- a/test/unit/routes/customer/personal-phone-numbers-change-routes.test.js
+++ b/test/unit/routes/customer/personal-phone-numbers-change-routes.test.js
@@ -1,0 +1,221 @@
+// Test framework dependencies
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+// Things we need to mock
+import { setSessionData } from '../../../../src/utils/session/set-session-data.js'
+import { fetchPersonalChangeService } from '../../../../src/services/personal/fetch-personal-change-service.js'
+
+// Thing under test
+import { personalPhoneNumbersChangeRoutes } from '../../../../src/routes/customer/personal-phone-numbers-change-routes.js'
+const [getPersonalPhoneNumbersChange, postPersonalPhoneNumbersChange] = personalPhoneNumbersChangeRoutes
+
+// Mocks
+vi.mock('../../../../src/utils/session/set-session-data.js', () => ({
+  setSessionData: vi.fn()
+}))
+
+vi.mock('../../../../src/services/personal/fetch-personal-change-service.js', () => ({
+  fetchPersonalChangeService: vi.fn()
+}))
+
+describe('personal phone numbers change', () => {
+  let request
+  let h
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    request = {
+      params: { crn: '1234567890' },
+      auth: { credentials: { email: 'test@example.com' } },
+      yar: {},
+      payload: {}
+    }
+
+    const responseStub = {
+      code: vi.fn().mockReturnThis(),
+      takeover: vi.fn().mockReturnThis()
+    }
+
+    h = {
+      redirect: vi.fn(),
+      view: vi.fn(() => responseStub)
+    }
+  })
+
+  describe('GET /customer/{crn}/account-phone-numbers-change', () => {
+    describe('when a request is valid', () => {
+      beforeEach(() => {
+        fetchPersonalChangeService.mockResolvedValue(getMockData())
+      })
+
+      test('should have the correct method and path configured', () => {
+        expect(getPersonalPhoneNumbersChange.method).toBe('GET')
+        expect(getPersonalPhoneNumbersChange.path).toBe('/customer/{crn}/account-phone-numbers-change')
+      })
+
+      test('it calls fetchPersonalChangeService', async () => {
+        await getPersonalPhoneNumbersChange.handler(request, h)
+
+        expect(fetchPersonalChangeService).toHaveBeenCalledWith(request.yar, '1234567890', 'test@example.com', 'changePersonalPhoneNumbers')
+      })
+
+      test('should render personal-phone-numbers-change view with page data', async () => {
+        await getPersonalPhoneNumbersChange.handler(request, h)
+
+        expect(h.view).toHaveBeenCalledWith('personal/personal-phone-numbers-change', getPageData())
+      })
+    })
+
+    describe('when the crn fails validation', () => {
+      beforeEach(() => {
+        request.params.crn = 'invalid-crn'
+      })
+
+      test('it redirects to the search-crn page and does not fetch data', async () => {
+        await getPersonalPhoneNumbersChange.handler(request, h)
+
+        expect(h.redirect).toHaveBeenCalledWith('/search-crn')
+        expect(fetchPersonalChangeService).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('POST /customer/{crn}/account-phone-numbers-change', () => {
+    beforeEach(() => {
+      request.payload = { personalTelephone: '01234567890', personalMobile: '07123456789' }
+
+      fetchPersonalChangeService.mockResolvedValue(getMockData())
+    })
+
+    test('should have the correct method and path configured', () => {
+      expect(postPersonalPhoneNumbersChange.method).toBe('POST')
+      expect(postPersonalPhoneNumbersChange.path).toBe('/customer/{crn}/account-phone-numbers-change')
+    })
+
+    describe('and the validation passes', () => {
+      test('it sets the session data and redirects to the check page', async () => {
+        await postPersonalPhoneNumbersChange.options.handler(request, h)
+
+        expect(setSessionData).toHaveBeenCalledWith(
+          request.yar,
+          'personalDetailsUpdate',
+          'changePersonalPhoneNumbers',
+          { personalTelephone: '01234567890', personalMobile: '07123456789' }
+        )
+        expect(h.redirect).toHaveBeenCalledWith('/customer/1234567890/account-phone-numbers-check')
+      })
+
+      test('it defaults missing numbers to null', async () => {
+        request.payload = { personalTelephone: '01234567890' }
+
+        await postPersonalPhoneNumbersChange.options.handler(request, h)
+
+        expect(setSessionData).toHaveBeenCalledWith(
+          request.yar,
+          'personalDetailsUpdate',
+          'changePersonalPhoneNumbers',
+          { personalTelephone: '01234567890', personalMobile: null }
+        )
+      })
+
+      test('it defaults a missing telephone to null', async () => {
+        request.payload = { personalMobile: '07123456789' }
+
+        await postPersonalPhoneNumbersChange.options.handler(request, h)
+
+        expect(setSessionData).toHaveBeenCalledWith(
+          request.yar,
+          'personalDetailsUpdate',
+          'changePersonalPhoneNumbers',
+          { personalTelephone: null, personalMobile: '07123456789' }
+        )
+      })
+    })
+
+    describe('and the validation fails', () => {
+      let err
+
+      beforeEach(() => {
+        err = {
+          details: [
+            {
+              message: 'Personal telephone number must be 10 characters or more',
+              path: ['personalTelephone'],
+              type: 'string.min'
+            }
+          ]
+        }
+      })
+
+      test('it fetches the personal details', async () => {
+        await postPersonalPhoneNumbersChange.options.validate.failAction(request, h, err)
+
+        expect(fetchPersonalChangeService).toHaveBeenCalledWith(
+          request.yar,
+          '1234567890',
+          'test@example.com',
+          'changePersonalPhoneNumbers'
+        )
+      })
+
+      test('it returns the page successfully with the error summary banner', async () => {
+        await postPersonalPhoneNumbersChange.options.validate.failAction(request, h, err)
+
+        expect(h.view).toHaveBeenCalledWith('personal/personal-phone-numbers-change', getPageDataError())
+      })
+
+      test('it should handle undefined errors', async () => {
+        await postPersonalPhoneNumbersChange.options.validate.failAction(request, h, [])
+
+        const pageData = getPageDataError()
+        pageData.errors = {}
+
+        expect(h.view).toHaveBeenCalledWith('personal/personal-phone-numbers-change', pageData)
+      })
+    })
+  })
+})
+
+const getMockData = () => {
+  return {
+    info: {
+      userName: 'John Doe',
+      fullName: {
+        first: 'John',
+        last: 'Doe'
+      }
+    },
+    contact: {
+      telephone: '01111111111',
+      mobile: '02222222222'
+    }
+  }
+}
+
+const getPageData = () => {
+  return {
+    backLink: { href: '/customer/1234567890/details' },
+    pageTitle: 'What are your personal phone numbers?',
+    metaDescription: 'Update the phone numbers for your personal account.',
+    userName: 'John Doe',
+    personalTelephone: '01111111111',
+    personalMobile: '02222222222'
+  }
+}
+
+const getPageDataError = () => {
+  return {
+    backLink: { href: '/customer/1234567890/details' },
+    pageTitle: 'What are your personal phone numbers?',
+    metaDescription: 'Update the phone numbers for your personal account.',
+    userName: 'John Doe',
+    personalTelephone: '01234567890',
+    personalMobile: '07123456789',
+    errors: {
+      personalTelephone: {
+        text: 'Personal telephone number must be 10 characters or more'
+      }
+    }
+  }
+}

--- a/test/unit/routes/customer/personal-phone-numbers-check-routes.test.js
+++ b/test/unit/routes/customer/personal-phone-numbers-check-routes.test.js
@@ -1,0 +1,141 @@
+// Test framework dependencies
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+// Things we need to mock
+import { fetchPersonalChangeService } from '../../../../src/services/personal/fetch-personal-change-service.js'
+import { updatePersonalPhoneNumbersChangeService } from '../../../../src/services/personal/update-personal-phone-numbers-change-service.js'
+
+// Thing under test
+import { personalPhoneNumbersCheckRoutes } from '../../../../src/routes/customer/personal-phone-numbers-check-routes.js'
+const [getPersonalPhoneNumbersCheck, postPersonalPhoneNumbersCheck] = personalPhoneNumbersCheckRoutes
+
+// Mocks
+vi.mock('../../../../src/services/personal/fetch-personal-change-service.js', () => ({
+  fetchPersonalChangeService: vi.fn()
+}))
+
+vi.mock('../../../../src/services/personal/update-personal-phone-numbers-change-service.js', () => ({
+  updatePersonalPhoneNumbersChangeService: vi.fn()
+}))
+
+describe('personal phone numbers check', () => {
+  let request
+  let h
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    request = {
+      params: { crn: '1234567890' },
+      auth: { credentials: { email: 'test@example.com' } },
+      yar: {}
+    }
+  })
+
+  describe('GET /customer/{crn}/account-phone-numbers-check', () => {
+    describe('when a request is valid', () => {
+      beforeEach(() => {
+        h = {
+          view: vi.fn().mockReturnValue({}),
+          redirect: vi.fn()
+        }
+
+        fetchPersonalChangeService.mockResolvedValue(getMockData())
+      })
+
+      test('should have the correct method and path configured', () => {
+        expect(getPersonalPhoneNumbersCheck.method).toBe('GET')
+        expect(getPersonalPhoneNumbersCheck.path).toBe('/customer/{crn}/account-phone-numbers-check')
+      })
+
+      test('it fetches the data from the session', async () => {
+        await getPersonalPhoneNumbersCheck.handler(request, h)
+
+        expect(fetchPersonalChangeService).toHaveBeenCalledWith(request.yar, '1234567890', 'test@example.com', 'changePersonalPhoneNumbers')
+      })
+
+      test('should render personal-phone-numbers-check view with page data', async () => {
+        await getPersonalPhoneNumbersCheck.handler(request, h)
+
+        expect(h.view).toHaveBeenCalledWith('personal/personal-phone-numbers-check', getPageData())
+      })
+    })
+
+    describe('when the crn fails validation', () => {
+      beforeEach(() => {
+        h = {
+          view: vi.fn(),
+          redirect: vi.fn().mockReturnValue({})
+        }
+
+        request.params.crn = 'invalid-crn'
+      })
+
+      test('it redirects to the search-crn page and does not fetch data', async () => {
+        await getPersonalPhoneNumbersCheck.handler(request, h)
+
+        expect(h.redirect).toHaveBeenCalledWith('/search-crn')
+        expect(fetchPersonalChangeService).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('POST /customer/{crn}/account-phone-numbers-check', () => {
+    beforeEach(() => {
+      h = {
+        redirect: vi.fn(() => h)
+      }
+    })
+
+    test('should have the correct method and path configured', () => {
+      expect(postPersonalPhoneNumbersCheck.method).toBe('POST')
+      expect(postPersonalPhoneNumbersCheck.path).toBe('/customer/{crn}/account-phone-numbers-check')
+    })
+
+    test('it calls updatePersonalPhoneNumbersChangeService with yar, crn and email', async () => {
+      await postPersonalPhoneNumbersCheck.handler(request, h)
+
+      expect(updatePersonalPhoneNumbersChangeService).toHaveBeenCalledWith(request.yar, '1234567890', 'test@example.com')
+    })
+
+    test('it redirects to the customer details page', async () => {
+      await postPersonalPhoneNumbersCheck.handler(request, h)
+
+      expect(h.redirect).toHaveBeenCalledWith('/customer/1234567890/details')
+    })
+  })
+})
+
+const getMockData = () => {
+  return {
+    info: {
+      userName: 'John Doe',
+      fullName: {
+        first: 'John',
+        last: 'Doe'
+      }
+    },
+    contact: {
+      telephone: '01111111111',
+      mobile: '02222222222'
+    },
+    changePersonalPhoneNumbers: {
+      personalTelephone: '01234567890',
+      personalMobile: '07123456789'
+    }
+  }
+}
+
+const getPageData = () => {
+  return {
+    backLink: { href: '/customer/1234567890/account-phone-numbers-change' },
+    changeLink: '/customer/1234567890/account-phone-numbers-change',
+    pageTitle: 'Check your personal phone numbers are correct before submitting',
+    metaDescription: 'Check the phone numbers for your personal account are correct.',
+    userName: 'John Doe',
+    personalTelephone: {
+      telephone: '01234567890',
+      mobile: '07123456789'
+    }
+  }
+}

--- a/test/unit/services/personal/update-personal-phone-numbers-change-service.test.js
+++ b/test/unit/services/personal/update-personal-phone-numbers-change-service.test.js
@@ -1,0 +1,153 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+// Things we need to mock
+import { mutations } from '@defra/fcp-sfd-frontend-engine'
+import { fetchPersonalChangeService } from '../../../../src/services/personal/fetch-personal-change-service.js'
+import { flashNotification } from '../../../../src/utils/notifications/flash-notification.js'
+import { updateDalService } from '../../../../src/services/DAL/update-dal-service.js'
+
+// Thing under test
+import { updatePersonalPhoneNumbersChangeService } from '../../../../src/services/personal/update-personal-phone-numbers-change-service.js'
+
+// Mocks
+vi.mock('../../../../src/services/personal/fetch-personal-change-service.js', () => ({
+  fetchPersonalChangeService: vi.fn()
+}))
+
+vi.mock('../../../../src/utils/notifications/flash-notification.js', () => ({
+  flashNotification: vi.fn()
+}))
+
+vi.mock('../../../../src/services/DAL/update-dal-service.js', () => ({
+  updateDalService: vi.fn().mockResolvedValue({})
+}))
+
+describe('updatePersonalPhoneNumbersChangeService', () => {
+  let yar
+  let crn
+  let email
+  let data
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    crn = '1234567890'
+    email = 'test@example.com'
+
+    data = {
+      crn,
+      info: {
+        userName: 'John Doe',
+        fullName: { first: 'John', last: 'Doe' }
+      },
+      contact: { telephone: '01111111111', mobile: '02222222222' },
+      changePersonalPhoneNumbers: {
+        personalTelephone: '09876543210',
+        personalMobile: '07123456789'
+      }
+    }
+
+    fetchPersonalChangeService.mockResolvedValue(data)
+
+    yar = { clear: vi.fn() }
+  })
+
+  describe('when called', () => {
+    test('it fetches the personal details with the crn and email', async () => {
+      await updatePersonalPhoneNumbersChangeService(yar, crn, email)
+
+      expect(fetchPersonalChangeService).toHaveBeenCalledWith(yar, crn, email, 'changePersonalPhoneNumbers')
+    })
+
+    test('it calls updateDalService with the correct mutation and variables', async () => {
+      await updatePersonalPhoneNumbersChangeService(yar, crn, email)
+
+      expect(updateDalService).toHaveBeenCalledWith(mutations.updateCustomerPhone, {
+        input: {
+          phone: {
+            landline: '09876543210',
+            mobile: '07123456789'
+          },
+          crn
+        }
+      }, email)
+    })
+
+    test('it clears the personalDetailsUpdate from session', async () => {
+      await updatePersonalPhoneNumbersChangeService(yar, crn, email)
+
+      expect(yar.clear).toHaveBeenCalledWith('personalDetailsUpdate')
+    })
+
+    test('adds a flash notification confirming the change in data', async () => {
+      await updatePersonalPhoneNumbersChangeService(yar, crn, email)
+
+      expect(flashNotification).toHaveBeenCalledWith(yar, 'Success', 'You have updated your personal phone numbers')
+    })
+  })
+
+  describe('when a phone number is null', () => {
+    beforeEach(() => {
+      data.changePersonalPhoneNumbers.personalTelephone = null
+    })
+
+    test('it calls updateDalService with a null landline', async () => {
+      await updatePersonalPhoneNumbersChangeService(yar, crn, email)
+
+      expect(updateDalService).toHaveBeenCalledWith(mutations.updateCustomerPhone, {
+        input: {
+          phone: {
+            landline: null,
+            mobile: '07123456789'
+          },
+          crn
+        }
+      }, email)
+    })
+  })
+
+  describe('when the mobile number is null', () => {
+    beforeEach(() => {
+      data.changePersonalPhoneNumbers.personalMobile = null
+    })
+
+    test('it calls updateDalService with a null mobile', async () => {
+      await updatePersonalPhoneNumbersChangeService(yar, crn, email)
+
+      expect(updateDalService).toHaveBeenCalledWith(mutations.updateCustomerPhone, {
+        input: {
+          phone: {
+            landline: '09876543210',
+            mobile: null
+          },
+          crn
+        }
+      }, email)
+    })
+  })
+
+  describe('when there is no changePersonalPhoneNumbers in session data', () => {
+    beforeEach(() => {
+      data.changePersonalPhoneNumbers = undefined
+    })
+
+    test('it returns early and does not call updateDalService', async () => {
+      await updatePersonalPhoneNumbersChangeService(yar, crn, email)
+
+      expect(updateDalService).not.toHaveBeenCalled()
+    })
+
+    test('it does not add a flash notification', async () => {
+      await updatePersonalPhoneNumbersChangeService(yar, crn, email)
+
+      expect(flashNotification).not.toHaveBeenCalled()
+    })
+
+    test('it does not clear personalDetailsUpdate from session', async () => {
+      await updatePersonalPhoneNumbersChangeService(yar, crn, email)
+
+      expect(yar.clear).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FLS2-56

## Summary

Adds the personal phone numbers change journey to the internal (staff-facing) service, allowing an internal user to view and update a customer's personal telephone and mobile numbers. This mirrors the existing personal name and personal email journeys and re-uses the shared `updateCustomerPhone` mutation and `schemas.personal.phone` validation from the engine.

## Changes

- Add crn-scoped routes `GET`/`POST /customer/{crn}/account-phone-numbers-change` and `.../account-phone-numbers-check`.
- Add local change and check presenters (change presenter uses the engine `presenters.formatNumber` helper to prefill both fields with payload → session → original fallback).
- Add `update-personal-phone-numbers-change-service.js`, which persists the change via `mutations.updateCustomerPhone`, clears the session draft and flashes a success notification.
- Add the change view (two `type="tel"` inputs with a shared "Enter at least one phone number" hint and an error summary via `toErrorList`) and the check view (a summary-list row showing both numbers with "Not added" fallbacks).
- Register the new route arrays in `routes.js`.
- Bump `@defra/fcp-sfd-frontend-engine` to `0.14.0`.

## Notes

- Validation (min 10 / max 50 / allowed characters / "at least one") is provided by the shared engine schema `schemas.personal.phone`; the "Enter at least one phone number" error is flagged on both fields and de-duplicated to a single error-summary link.
- The customer details page phone "Change/Add" link already points to this journey, so no change was needed there.
- Depends on engine PR DEFRA/fcp-sfd-frontend-engine#56. The lockfile and CI will only go green once engine `0.14.0` is merged and published to npm; the lockfile then needs regenerating (`npm install`).

## Fixes

- Guard the phone check presenter against a missing session draft. After submitting, the draft is cleared; navigating back to the check page (e.g. browser back button) previously read a nested property off the now-undefined draft and returned a 500. The presenter now falls back to the saved phone numbers, matching the name/email/address check presenters.
