### PR TITLE
FLS2-47: Show success banner on business details page

### DIFF
--- a/src/presenters/business/business-details-presenter.js
+++ b/src/presenters/business/business-details-presenter.js
@@ -8,13 +8,14 @@ import { BUSINESS_CHANGE_LINKS } from '../../constants/change-links.js'
 
 const CHANGE_LINK = '#'
 
-const businessDetailsPresenter = (data, sbi) => {
+const businessDetailsPresenter = (data, sbi, yar) => {
   const { info, address, contact } = data
   const countyParishHoldingNumbers = presenters.formatCph(info.countyParishHoldingNumbers)
   const addressLines = presenters.formatBusinessAddress(address)
   const hasAddress = addressLines.length > 0
 
   return {
+    notification: yar ? yar.flash('notification')[0] : null,
     pageTitle: 'View and update your business details',
     metaDescription: 'View and update your business details.',
     sbi,

--- a/src/routes/business/business-details-routes.js
+++ b/src/routes/business/business-details-routes.js
@@ -23,7 +23,7 @@ const getBusinessDetails = {
 
     const email = auth.credentials?.email
     const businessDetails = await fetchBusinessDetailsService(sbi, email)
-    const pageData = businessDetailsPresenter(businessDetails, sbi)
+    const pageData = businessDetailsPresenter(businessDetails, sbi, yar)
 
     return h.view('business/business-details', pageData)
   }

--- a/src/views/business/business-details.njk
+++ b/src/views/business/business-details.njk
@@ -1,6 +1,7 @@
 {% extends 'common/layout.njk' %}
 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "common/navigation/breadcrumbs-sign-out-link.njk" import appBreadcrumbsSignOutLink with context %}
 
 {% block beforeContent %}
@@ -11,6 +12,23 @@
 <div class="govuk-main-wrapper">
   <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
+    {# Notification banner #}
+    {% if notification %}
+      {% if notification.html %}
+        {{ govukNotificationBanner({
+          type: "success",
+          titleText: notification.title,
+          html: notification.html
+        })}}
+      {% else %}
+        {{ govukNotificationBanner({
+          type: "success",
+          titleText: notification.title,
+          text: notification.text
+        })}}
+      {% endif %}
+    {% endif %}
 
     <h1 class="govuk-heading-l">
       {{ pageTitle }}

--- a/test/unit/presenters/business/business-details-presenter.test.js
+++ b/test/unit/presenters/business/business-details-presenter.test.js
@@ -1,5 +1,5 @@
 // Test framework dependencies
-import { describe, test, expect, beforeEach } from 'vitest'
+import { describe, test, expect, beforeEach, vi } from 'vitest'
 
 // Thing under test
 import { businessDetailsPresenter } from '../../../../src/presenters/business/business-details-presenter.js'
@@ -46,6 +46,33 @@ describe('businessDetailsPresenter', () => {
     const result = businessDetailsPresenter(data, sbi)
 
     expect(result.sbi).toBe(sbi)
+  })
+
+  describe('the "notification" property', () => {
+    test('returns the flash notification when yar has one', () => {
+      const yar = {
+        flash: vi.fn().mockReturnValue([{ title: 'Success', text: 'You have updated your business email address' }])
+      }
+
+      const result = businessDetailsPresenter(data, sbi, yar)
+
+      expect(yar.flash).toHaveBeenCalledWith('notification')
+      expect(result.notification).toEqual({ title: 'Success', text: 'You have updated your business email address' })
+    })
+
+    test('returns undefined when yar has no flash notification', () => {
+      const yar = { flash: vi.fn().mockReturnValue([]) }
+
+      const result = businessDetailsPresenter(data, sbi, yar)
+
+      expect(result.notification).toBeUndefined()
+    })
+
+    test('returns null when yar is not provided', () => {
+      const result = businessDetailsPresenter(data, sbi)
+
+      expect(result.notification).toBeNull()
+    })
   })
 
   test('returns breadcrumbs for search results and the business overview', () => {

--- a/test/unit/routes/business/business-details-routes.test.js
+++ b/test/unit/routes/business/business-details-routes.test.js
@@ -32,7 +32,8 @@ describe('business details routes', () => {
         credentials: { email: 'test.user@defra.gov.uk' }
       },
       yar: {
-        set: vi.fn()
+        set: vi.fn(),
+        flash: vi.fn().mockReturnValue([])
       }
     }
 
@@ -61,7 +62,7 @@ describe('business details routes', () => {
         await getBusinessDetails.handler(request, h)
 
         expect(fetchBusinessDetailsService).toHaveBeenCalledWith('106705779', 'test.user@defra.gov.uk')
-        expect(businessDetailsPresenter).toHaveBeenCalledWith(businessDetails, '106705779')
+        expect(businessDetailsPresenter).toHaveBeenCalledWith(businessDetails, '106705779', request.yar)
         expect(h.view).toHaveBeenCalledWith('business/business-details', pageData)
       })
 


### PR DESCRIPTION
## What
Fixes a bug where the success confirmation banner was **not visible** after successfully updating a business email address. The update service already sets the flash notification and the check page already redirects back to `/business/{sbi}/details`, but the business details page never read or rendered it.

Reported by QA.

## Root cause
The business details page was missing the notification wiring that the **personal details** journey already has. Three pieces were absent on the business journey:
- the route handler did not pass `yar` to the presenter
- the presenter did not read `yar.flash('notification')`
- the view did not render `govukNotificationBanner`

## Changes (mirrors the working personal-details journey)
- `business-details-routes.js` — pass `yar` to `businessDetailsPresenter`
- `business-details-presenter.js` — add `notification: yar ? yar.flash('notification')[0] : null`
- `business-details.njk` — import and render the `govukNotificationBanner` success banner

## Scope
This restores the banner for the already-merged **business email** journey. The **business name** journey (open in #143) will benefit from the same page automatically once it merges — no name-specific work is included here.

## Testing
- `npm test` — updated route + presenter unit tests pass (35 tests)
- `eslint` — clean on changed files
- Manual: update business email → redirected to details → green "You have updated your business email address" banner now shows