### PR TITLE
FLS2-44: An internal user can update business name (part 2)

### DIFF
--- a/src/presenters/business/business-name-check-presenter.js
+++ b/src/presenters/business/business-name-check-presenter.js
@@ -1,0 +1,27 @@
+/**
+ * Formats data ready for presenting in the `business-name-check` page
+ * @module businessNameCheckPresenter
+ */
+
+import { resolveBackLink } from '../base-presenter.js'
+import { BUSINESS_CHANGE_LINKS } from '../../constants/change-links.js'
+
+const businessNameCheckPresenter = (data, referrer) => {
+  const sbi = data.info?.sbi ?? null
+  const fallbackHref = sbi ? BUSINESS_CHANGE_LINKS.businessName(sbi) : '/search-sbi'
+
+  return {
+    backLink: {
+      backLink: true,
+      href: resolveBackLink(referrer, fallbackHref)
+    },
+    changeLink: fallbackHref,
+    pageTitle: 'Check your business name is correct before submitting',
+    metaDescription: 'Check the name for your business is correct.',
+    userName: data.customer?.userName ?? null,
+    businessName: data.changeBusinessName ?? data.info?.businessName ?? null,
+    sbi
+  }
+}
+
+export { businessNameCheckPresenter }

--- a/src/routes/business/business-name-change-routes.js
+++ b/src/routes/business/business-name-change-routes.js
@@ -48,9 +48,7 @@ const postBusinessNameChange = {
 
       setSessionData(request.yar, 'businessDetailsUpdate', 'changeBusinessName', request.payload.businessName)
 
-      // Redirect to the business details page as an interim destination. Part 2 adds the
-      // `/business/{sbi}/business-name-check` route and this will be pointed at it then.
-      return h.redirect(`/business/${sbi}/details`)
+      return h.redirect(`/business/${sbi}/business-name-check`)
     }
   }
 }

--- a/src/routes/business/business-name-check-routes.js
+++ b/src/routes/business/business-name-check-routes.js
@@ -1,0 +1,44 @@
+import { fetchBusinessChangeService } from '../../services/business/fetch-business-change-service.js'
+import { updateBusinessNameChangeService } from '../../services/business/update-business-name-change-service.js'
+import { businessNameCheckPresenter } from '../../presenters/business/business-name-check-presenter.js'
+import { validateSbi } from '../pre-handlers.js'
+
+const getBusinessNameCheck = {
+  method: 'GET',
+  path: '/business/{sbi}/business-name-check',
+  options: {
+    pre: [validateSbi]
+  },
+  handler: async (request, h) => {
+    const { params, yar, auth, info } = request
+    const { sbi } = params
+
+    yar.set('businessDetailsUpdate', { ...yar.get('businessDetailsUpdate'), sbi })
+
+    const businessNameChange = await fetchBusinessChangeService(yar, auth.credentials, 'changeBusinessName')
+    const pageData = businessNameCheckPresenter(businessNameChange, info.referrer)
+
+    return h.view('business/business-name-check', pageData)
+  }
+}
+
+const postBusinessNameCheck = {
+  method: 'POST',
+  path: '/business/{sbi}/business-name-check',
+  options: {
+    pre: [validateSbi]
+  },
+  handler: async (request, h) => {
+    const { params, yar, auth } = request
+    const { sbi } = params
+
+    await updateBusinessNameChangeService(yar, auth.credentials)
+
+    return h.redirect(`/business/${sbi}/details`)
+  }
+}
+
+export const businessNameCheckRoutes = [
+  getBusinessNameCheck,
+  postBusinessNameCheck
+]

--- a/src/routes/business/business-name-check-routes.js
+++ b/src/routes/business/business-name-check-routes.js
@@ -32,6 +32,8 @@ const postBusinessNameCheck = {
     const { params, yar, auth } = request
     const { sbi } = params
 
+    yar.set('businessDetailsUpdate', { ...yar.get('businessDetailsUpdate'), sbi })
+
     await updateBusinessNameChangeService(yar, auth.credentials)
 
     return h.redirect(`/business/${sbi}/details`)

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -22,6 +22,7 @@ import { businessDetailsRoutes } from './business/business-details-routes.js'
 import { businessEmailChangeRoutes } from './business/business-email-change-routes.js'
 import { businessEmailCheckRoutes } from './business/business-email-check-routes.js'
 import { businessNameChangeRoutes } from './business/business-name-change-routes.js'
+import { businessNameCheckRoutes } from './business/business-name-check-routes.js'
 
 export const routes = [
   health,
@@ -47,5 +48,6 @@ export const routes = [
   ...businessDetailsRoutes,
   ...businessEmailChangeRoutes,
   ...businessEmailCheckRoutes,
-  ...businessNameChangeRoutes
+  ...businessNameChangeRoutes,
+  ...businessNameCheckRoutes
 ]

--- a/src/services/business/update-business-name-change-service.js
+++ b/src/services/business/update-business-name-change-service.js
@@ -1,0 +1,36 @@
+/**
+ * Service to update a business's name
+ *
+ * Fetches the pending business name change from the session
+ * Calls the DAL to persist the updated name using updateDalService
+ * Clears the cached business details data from the session
+ * Displays a success flash notification to the user
+ *
+ * @module updateBusinessNameChangeService
+ */
+
+import { mutations, utils, constants } from '@defra/fcp-sfd-frontend-engine'
+
+import { updateDalService } from '../DAL/update-dal-service.js'
+import { fetchBusinessChangeService } from './fetch-business-change-service.js'
+import { flashNotification } from '../../utils/notifications/flash-notification.js'
+
+const updateBusinessNameChangeService = async (yar, credentials) => {
+  const businessDetails = await fetchBusinessChangeService(yar, credentials, 'changeBusinessName')
+
+  if (!businessDetails.changeBusinessName) {
+    return
+  }
+
+  const variables = utils.buildUpdateBusinessNameVariables(businessDetails.changeBusinessName, businessDetails.info.sbi)
+
+  await updateDalService(mutations.updateBusinessName, variables, credentials.email)
+
+  yar.clear('businessDetailsUpdate')
+
+  flashNotification(yar, 'Success', constants.successMessages.BUSINESS_NAME)
+}
+
+export {
+  updateBusinessNameChangeService
+}

--- a/src/views/business/business-name-check.njk
+++ b/src/views/business/business-name-check.njk
@@ -1,0 +1,47 @@
+{% extends 'common/layout.njk' %}
+
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "common/navigation/back-sign-out-link.njk" import appBackSignOutLink with context %}
+
+{% block beforeContent %}
+  {{ appBackSignOutLink(backLink) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <form method="post" novalidate>
+      <input type="hidden" name="crumb" value="{{ crumb }}">
+      <h1 class="govuk-heading-l">
+        {{ pageTitle }}
+      </h1>
+
+      {{ govukSummaryList({
+        rows: [
+          {
+            key: {
+              text: "Business name"
+            },
+            value: {
+              text: businessName
+            },
+            actions: {
+              items: [
+                {
+                  href: changeLink,
+                  text: "Change",
+                  visuallyHiddenText: "business name",
+                  classes: "govuk-link--no-visited-state"
+                }
+              ]
+            }
+          }
+        ]
+      }) }}
+
+      {{ govukButton({ text: "Submit", preventDoubleClick: true }) }}
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/test/integration/narrow/routes/business/business-name-check-routes.test.js
+++ b/test/integration/narrow/routes/business/business-name-check-routes.test.js
@@ -1,0 +1,80 @@
+import { constants } from 'node:http2'
+import { vi, beforeAll, afterAll, describe, test, expect } from 'vitest'
+import { SCOPE } from '../../../../../src/constants/scope/business-details.js'
+import '../../../../mocks/setup-server-mocks.js'
+
+const { HTTP_STATUS_OK, HTTP_STATUS_FORBIDDEN } = constants
+
+vi.mock('../../../../../src/services/business/fetch-business-change-service.js', () => ({
+  fetchBusinessChangeService: vi.fn()
+}))
+
+vi.mock('../../../../../src/services/business/update-business-name-change-service.js', () => ({
+  updateBusinessNameChangeService: vi.fn()
+}))
+
+const { fetchBusinessChangeService } = await import('../../../../../src/services/business/fetch-business-change-service.js')
+const { updateBusinessNameChangeService } = await import('../../../../../src/services/business/update-business-name-change-service.js')
+const { createServer } = await import('../../../../../src/server.js')
+
+describe('business name check route', () => {
+  const sbi = '106705779'
+  const path = `/business/${sbi}/business-name-check`
+  let server
+
+  beforeAll(async () => {
+    vi.clearAllMocks()
+
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    if (server) {
+      await server.stop()
+    }
+  })
+
+  describe('GET /business/{sbi}/business-name-check', () => {
+    test('returns 200 and renders the business name check view when authenticated', async () => {
+      fetchBusinessChangeService.mockResolvedValue({
+        info: { sbi, businessName: 'Herberts Lawn Mowing' },
+        changeBusinessName: 'New Farm Ltd'
+      })
+
+      const response = await server.inject({
+        url: path,
+        auth: {
+          strategy: 'session',
+          credentials: {
+            sessionId: 'session-id',
+            scope: SCOPE
+          }
+        }
+      })
+
+      expect(response.statusCode).toBe(HTTP_STATUS_OK)
+      expect(response.request.response.source.template).toBe('business/business-name-check')
+    })
+  })
+
+  describe('POST /business/{sbi}/business-name-check', () => {
+    test('is rejected with 403 when the CSRF crumb is missing', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: path,
+        payload: {},
+        auth: {
+          strategy: 'session',
+          credentials: {
+            sessionId: 'session-id',
+            scope: SCOPE
+          }
+        }
+      })
+
+      expect(response.statusCode).toBe(HTTP_STATUS_FORBIDDEN)
+      expect(updateBusinessNameChangeService).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/test/unit/presenters/business/business-name-check-presenter.test.js
+++ b/test/unit/presenters/business/business-name-check-presenter.test.js
@@ -1,0 +1,127 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach } from 'vitest'
+
+// Thing under test
+import { businessNameCheckPresenter } from '../../../../src/presenters/business/business-name-check-presenter.js'
+
+describe('businessNameCheckPresenter', () => {
+  let data
+  let referrer
+
+  beforeEach(() => {
+    data = {
+      info: { sbi: '106705779', businessName: 'Herberts Lawn Mowing' }
+    }
+    referrer = undefined
+  })
+
+  describe('when provided with business name check data', () => {
+    test('it correctly presents the data', () => {
+      const result = businessNameCheckPresenter(data, referrer)
+
+      expect(result).toEqual({
+        backLink: { backLink: true, href: '/business/106705779/business-name-change' },
+        changeLink: '/business/106705779/business-name-change',
+        pageTitle: 'Check your business name is correct before submitting',
+        metaDescription: 'Check the name for your business is correct.',
+        userName: null,
+        businessName: 'Herberts Lawn Mowing',
+        sbi: '106705779'
+      })
+    })
+  })
+
+  describe('the "backLink" property', () => {
+    describe('when the referrer is a valid url', () => {
+      beforeEach(() => {
+        referrer = 'https://example.com/business/106705779/business-name-change'
+      })
+
+      test('it builds the back link from the referrer', () => {
+        const result = businessNameCheckPresenter(data, referrer)
+
+        expect(result.backLink).toEqual({ backLink: true, href: '/business/106705779/business-name-change' })
+      })
+    })
+
+    describe('when there is no referrer', () => {
+      test('it falls back to the business name change page', () => {
+        const result = businessNameCheckPresenter(data, referrer)
+
+        expect(result.backLink).toEqual({ backLink: true, href: '/business/106705779/business-name-change' })
+      })
+    })
+
+    describe('when there is no referrer and the sbi is missing', () => {
+      beforeEach(() => {
+        delete data.info.sbi
+      })
+
+      test('it falls back to the search page', () => {
+        const result = businessNameCheckPresenter(data, referrer)
+
+        expect(result.backLink).toEqual({ backLink: true, href: '/search-sbi' })
+        expect(result.changeLink).toBe('/search-sbi')
+      })
+    })
+  })
+
+  describe('the "businessName" property', () => {
+    describe('when there is an in-progress change', () => {
+      beforeEach(() => {
+        data.changeBusinessName = 'New Farm Ltd'
+      })
+
+      test('it uses the in-progress change name', () => {
+        const result = businessNameCheckPresenter(data, referrer)
+
+        expect(result.businessName).toBe('New Farm Ltd')
+      })
+    })
+
+    describe('when there is no in-progress change', () => {
+      test('it falls back to the current business name', () => {
+        const result = businessNameCheckPresenter(data, referrer)
+
+        expect(result.businessName).toBe('Herberts Lawn Mowing')
+      })
+    })
+  })
+
+  describe('the "userName" property', () => {
+    describe('when a customer is present', () => {
+      beforeEach(() => {
+        data.customer = { userName: 'Jane Doe' }
+      })
+
+      test('it returns the userName', () => {
+        const result = businessNameCheckPresenter(data, referrer)
+
+        expect(result.userName).toBe('Jane Doe')
+      })
+    })
+
+    describe('when there is no customer', () => {
+      test('it defaults the userName to null', () => {
+        const result = businessNameCheckPresenter(data, referrer)
+
+        expect(result.userName).toBeNull()
+      })
+    })
+  })
+
+  describe('when the "info" object is missing', () => {
+    beforeEach(() => {
+      data = {}
+    })
+
+    test('it defaults businessName and sbi to null and falls back to the search page', () => {
+      const result = businessNameCheckPresenter(data, referrer)
+
+      expect(result.businessName).toBeNull()
+      expect(result.sbi).toBeNull()
+      expect(result.backLink).toEqual({ backLink: true, href: '/search-sbi' })
+      expect(result.changeLink).toBe('/search-sbi')
+    })
+  })
+})

--- a/test/unit/routes/business/business-name-change-routes.test.js
+++ b/test/unit/routes/business/business-name-change-routes.test.js
@@ -138,11 +138,11 @@ describe('business name change routes', () => {
       expect(postBusinessNameChange.options.pre).toContain(validateSbi)
     })
 
-    test('stores the submitted name in session and redirects to the business details page', async () => {
+    test('stores the submitted name in session and redirects to the business name check page', async () => {
       await postBusinessNameChange.options.handler(request, h)
 
       expect(setSessionData).toHaveBeenCalledWith(request.yar, 'businessDetailsUpdate', 'changeBusinessName', 'New Farm Ltd')
-      expect(h.redirect).toHaveBeenCalledWith('/business/106705779/details')
+      expect(h.redirect).toHaveBeenCalledWith('/business/106705779/business-name-check')
     })
   })
 })

--- a/test/unit/routes/business/business-name-check-routes.test.js
+++ b/test/unit/routes/business/business-name-check-routes.test.js
@@ -1,0 +1,120 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+// Things we need to mock
+import { fetchBusinessChangeService } from '../../../../src/services/business/fetch-business-change-service.js'
+import { updateBusinessNameChangeService } from '../../../../src/services/business/update-business-name-change-service.js'
+import { businessNameCheckPresenter } from '../../../../src/presenters/business/business-name-check-presenter.js'
+
+// Shared pre-handler used to guard the SBI
+import { validateSbi } from '../../../../src/routes/pre-handlers.js'
+
+// Thing under test
+import { businessNameCheckRoutes } from '../../../../src/routes/business/business-name-check-routes.js'
+
+const [getBusinessNameCheck, postBusinessNameCheck] = businessNameCheckRoutes
+
+// Mocks
+vi.mock('../../../../src/services/business/fetch-business-change-service.js', () => ({
+  fetchBusinessChangeService: vi.fn()
+}))
+
+vi.mock('../../../../src/services/business/update-business-name-change-service.js', () => ({
+  updateBusinessNameChangeService: vi.fn()
+}))
+
+vi.mock('../../../../src/presenters/business/business-name-check-presenter.js', () => ({
+  businessNameCheckPresenter: vi.fn()
+}))
+
+describe('business name check routes', () => {
+  let request
+  let h
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    request = {
+      params: { sbi: '106705779' },
+      yar: { get: vi.fn().mockReturnValue({ sbi: '106705779' }), set: vi.fn() },
+      auth: { credentials: { email: 'test.user@defra.gov.uk' } },
+      info: { referrer: 'https://example.com/business/106705779/business-name-change' }
+    }
+
+    h = {
+      view: vi.fn(),
+      redirect: vi.fn().mockReturnValue({ takeover: vi.fn() })
+    }
+  })
+
+  describe('GET /business/{sbi}/business-name-check', () => {
+    const businessNameChange = { info: { sbi: '106705779' } }
+    const pageData = { pageTitle: 'Check your business name is correct before submitting' }
+
+    beforeEach(() => {
+      fetchBusinessChangeService.mockResolvedValue(businessNameChange)
+      businessNameCheckPresenter.mockReturnValue(pageData)
+    })
+
+    test('should have the correct method and path configured', () => {
+      expect(getBusinessNameCheck.method).toBe('GET')
+      expect(getBusinessNameCheck.path).toBe('/business/{sbi}/business-name-check')
+    })
+
+    test('guards the route with the shared validateSbi pre-handler', () => {
+      expect(getBusinessNameCheck.options.pre).toContain(validateSbi)
+    })
+
+    test('fetches the business change details, presents them and renders the page', async () => {
+      await getBusinessNameCheck.handler(request, h)
+
+      expect(fetchBusinessChangeService).toHaveBeenCalledWith(request.yar, request.auth.credentials, 'changeBusinessName')
+      expect(businessNameCheckPresenter).toHaveBeenCalledWith(businessNameChange, request.info.referrer)
+      expect(h.view).toHaveBeenCalledWith('business/business-name-check', pageData)
+    })
+
+    test('persists the sbi in session', async () => {
+      await getBusinessNameCheck.handler(request, h)
+
+      expect(request.yar.set).toHaveBeenCalledWith('businessDetailsUpdate', { sbi: '106705779' })
+    })
+
+    describe('when fetchBusinessChangeService throws', () => {
+      beforeEach(() => {
+        fetchBusinessChangeService.mockRejectedValue(new Error('Business not found'))
+      })
+
+      test('throws the error from the service', async () => {
+        await expect(getBusinessNameCheck.handler(request, h)).rejects.toThrow('Business not found')
+      })
+    })
+  })
+
+  describe('POST /business/{sbi}/business-name-check', () => {
+    test('should have the correct method and path configured', () => {
+      expect(postBusinessNameCheck.method).toBe('POST')
+      expect(postBusinessNameCheck.path).toBe('/business/{sbi}/business-name-check')
+    })
+
+    test('guards the route with the shared validateSbi pre-handler', () => {
+      expect(postBusinessNameCheck.options.pre).toContain(validateSbi)
+    })
+
+    test('updates the name and redirects to the business details page for the sbi', async () => {
+      await postBusinessNameCheck.handler(request, h)
+
+      expect(updateBusinessNameChangeService).toHaveBeenCalledWith(request.yar, request.auth.credentials)
+      expect(h.redirect).toHaveBeenCalledWith('/business/106705779/details')
+    })
+
+    describe('when updateBusinessNameChangeService throws', () => {
+      beforeEach(() => {
+        updateBusinessNameChangeService.mockRejectedValue(new Error('Update failed'))
+      })
+
+      test('throws the error from the service', async () => {
+        await expect(postBusinessNameCheck.handler(request, h)).rejects.toThrow('Update failed')
+      })
+    })
+  })
+})

--- a/test/unit/services/business/update-business-name-change-service.test.js
+++ b/test/unit/services/business/update-business-name-change-service.test.js
@@ -1,0 +1,107 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+// Mock dependencies
+const mockFetchBusinessChangeService = vi.fn()
+const mockUpdateDalService = vi.fn()
+const mockFlashNotification = vi.fn()
+
+vi.mock('../../../../src/services/business/fetch-business-change-service.js', () => ({
+  fetchBusinessChangeService: mockFetchBusinessChangeService
+}))
+
+vi.mock('../../../../src/services/DAL/update-dal-service.js', () => ({
+  updateDalService: mockUpdateDalService
+}))
+
+vi.mock('@defra/fcp-sfd-frontend-engine', () => ({
+  mutations: { updateBusinessName: 'update-business-name-mutation' },
+  utils: {
+    buildUpdateBusinessNameVariables: (name, sbi) => ({ input: { name, sbi } })
+  },
+  constants: {
+    successMessages: { BUSINESS_NAME: 'You have updated your business name' }
+  }
+}))
+
+vi.mock('../../../../src/utils/notifications/flash-notification.js', () => ({
+  flashNotification: mockFlashNotification
+}))
+
+// Thing under test
+const { updateBusinessNameChangeService } = await import('../../../../src/services/business/update-business-name-change-service.js')
+
+describe('updateBusinessNameChangeService', () => {
+  let yar
+  let credentials
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    credentials = { email: 'test.user@defra.gov.uk' }
+
+    yar = {
+      clear: vi.fn()
+    }
+
+    mockFetchBusinessChangeService.mockResolvedValue({
+      changeBusinessName: 'New Farm Ltd',
+      info: { sbi: '107183280' }
+    })
+  })
+
+  test('fetches the pending business name change from session', async () => {
+    await updateBusinessNameChangeService(yar, credentials)
+
+    expect(mockFetchBusinessChangeService).toHaveBeenCalledWith(yar, credentials, 'changeBusinessName')
+  })
+
+  test('persists the updated name via the DAL', async () => {
+    await updateBusinessNameChangeService(yar, credentials)
+
+    expect(mockUpdateDalService).toHaveBeenCalledWith(
+      'update-business-name-mutation',
+      { input: { name: 'New Farm Ltd', sbi: '107183280' } },
+      credentials.email
+    )
+  })
+
+  test('clears the cached business details from session', async () => {
+    await updateBusinessNameChangeService(yar, credentials)
+
+    expect(yar.clear).toHaveBeenCalledWith('businessDetailsUpdate')
+  })
+
+  test('displays a success flash notification', async () => {
+    await updateBusinessNameChangeService(yar, credentials)
+
+    expect(mockFlashNotification).toHaveBeenCalledWith(yar, 'Success', 'You have updated your business name')
+  })
+
+  describe('when there is no pending business name change', () => {
+    beforeEach(() => {
+      mockFetchBusinessChangeService.mockResolvedValue({ info: { sbi: '107183280' } })
+    })
+
+    test('returns early without calling the DAL, clearing session or notifying', async () => {
+      await updateBusinessNameChangeService(yar, credentials)
+
+      expect(mockUpdateDalService).not.toHaveBeenCalled()
+      expect(yar.clear).not.toHaveBeenCalled()
+      expect(mockFlashNotification).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the DAL update fails', () => {
+    beforeEach(() => {
+      mockUpdateDalService.mockRejectedValue(new Error('DAL unavailable'))
+    })
+
+    test('propagates the error without clearing session or notifying', async () => {
+      await expect(updateBusinessNameChangeService(yar, credentials)).rejects.toThrow('DAL unavailable')
+
+      expect(yar.clear).not.toHaveBeenCalled()
+      expect(mockFlashNotification).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## What

Completes the business name change journey started in #143. Adds the check/confirmation page and submission service, allowing internal staff to review and submit their business name update.

This is **part 2 of 2**. Part 1 (#143) added the change page and wiring to the business details view.

## Changes

- New `GET`/`POST /business/{sbi}/business-name-check` route (guarded by shared `validateSbi` pre-handler)
- New `businessNameCheckPresenter` and `business-name-check.njk` view
- New `updateBusinessNameChangeService` using the engine's shared `updateBusinessName` mutation, variable builder and success message (from v0.15.0)
- Repoint the business-name-change POST from an interim `/details` redirect to the new check page
- Register the new routes

## Testing

- `npm test` — all 906 unit tests pass across 123 files (including 2 new integration tests for CSRF coverage)
- `npm run lint` — no lint errors introduced
- Manually tested the full journey: change page → check page → submission → success notification + redirect to details

## Dependencies

- Requires `@defra/fcp-sfd-frontend-engine` v0.15.0 or later (already installed in main post-#143)
- Follows the pattern established by #134 (business email change) and part 1 (#143)

## Notes

This completes the internal frontend part of FLS2-44. External frontend refactoring (to use the shared engine code instead of local mutation) is separate but ready to follow once this merges.