### PR TITLE
FLS2-13: Remove Moment.js Dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@defra/fcp-sfd-frontend-engine": "0.22.0",
+        "@defra/fcp-sfd-frontend-engine": "0.22.1",
         "@defra/hapi-tracing": "1.30.0",
         "@elastic/ecs-pino-format": "1.5.0",
         "@hapi/bell": "13.1.0",
@@ -490,9 +490,9 @@
       "license": "MIT"
     },
     "node_modules/@defra/fcp-sfd-frontend-engine": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.22.0.tgz",
-      "integrity": "sha512-HuLLcdyyeVrXdZKPDigPFV15en3cLBRQoA0Ad12N6IRa4gP9zOr28PEy78AUschqjWwm+LH0OtIYdP1acqX7NQ==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.22.1.tgz",
+      "integrity": "sha512-MWBunuvJy7uR8YZmmWLCKmpzrkNb3u1Yb+pyaXhpwziEyYZXVpvJP4QYig44THYHeQsGk2DTxdbKOhrq3rxVRg==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "joi": "18.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@defra/fcp-sfd-frontend-engine": "0.20.0",
+        "@defra/fcp-sfd-frontend-engine": "0.22.0",
         "@defra/hapi-tracing": "1.30.0",
         "@elastic/ecs-pino-format": "1.5.0",
         "@hapi/bell": "13.1.0",
@@ -39,7 +39,6 @@
         "hapi-pulse": "3.0.1",
         "https-proxy-agent": "9.0.0",
         "ioredis": "5.10.1",
-        "moment": "2.30.1",
         "nunjucks": "3.2.4",
         "pino": "10.3.1",
         "pino-pretty": "13.1.3",
@@ -491,9 +490,9 @@
       "license": "MIT"
     },
     "node_modules/@defra/fcp-sfd-frontend-engine": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.20.0.tgz",
-      "integrity": "sha512-ysmvxNz3pJqyOOFMB14LJpdbFxA72FTVKWE7tP4M6b3wwvSNBfDGnBr7tlSKZlziR+TWyG2xAaK4rKPtdD/lHQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.22.0.tgz",
+      "integrity": "sha512-HuLLcdyyeVrXdZKPDigPFV15en3cLBRQoA0Ad12N6IRa4gP9zOr28PEy78AUschqjWwm+LH0OtIYdP1acqX7NQ==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "joi": "18.2.3",
@@ -1703,9 +1702,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1727,9 +1723,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1751,9 +1744,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1775,9 +1765,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1799,9 +1786,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1823,9 +1807,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2001,9 +1982,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2021,9 +1999,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2041,9 +2016,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2061,9 +2033,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2081,9 +2050,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2101,9 +2067,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5388,6 +5351,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7237,9 +7201,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7261,9 +7222,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7285,9 +7243,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7309,9 +7264,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7768,15 +7720,6 @@
         "uglify-js": {
           "optional": true
         }
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -10415,7 +10358,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10433,7 +10375,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10451,7 +10392,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10469,7 +10409,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10487,7 +10426,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10505,7 +10443,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10523,7 +10460,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10541,7 +10477,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "license": "OGL-UK-3.0",
   "dependencies": {
-    "@defra/fcp-sfd-frontend-engine": "0.22.0",
+    "@defra/fcp-sfd-frontend-engine": "0.22.1",
     "@defra/hapi-tracing": "1.30.0",
     "@elastic/ecs-pino-format": "1.5.0",
     "@hapi/bell": "13.1.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "license": "OGL-UK-3.0",
   "dependencies": {
-    "@defra/fcp-sfd-frontend-engine": "0.20.0",
+    "@defra/fcp-sfd-frontend-engine": "0.22.0",
     "@defra/hapi-tracing": "1.30.0",
     "@elastic/ecs-pino-format": "1.5.0",
     "@hapi/bell": "13.1.0",
@@ -74,7 +74,6 @@
     "hapi-pulse": "3.0.1",
     "https-proxy-agent": "9.0.0",
     "ioredis": "5.10.1",
-    "moment": "2.30.1",
     "nunjucks": "3.2.4",
     "pino": "10.3.1",
     "pino-pretty": "13.1.3",

--- a/src/presenters/personal/personal-details-presenter.js
+++ b/src/presenters/personal/personal-details-presenter.js
@@ -3,7 +3,6 @@
  * @module personalDetailsPresenter
  */
 
-import moment from 'moment'
 import { presenters } from '@defra/fcp-sfd-frontend-engine'
 import { config } from '../../config/index.js'
 
@@ -105,14 +104,15 @@ const formatDob = (dob) => {
     return { formattedDob: 'Not added', action: 'Add' }
   }
 
-  const dobMoment = moment(dob)
+  const date = new Date(dob)
 
-  if (!dobMoment.isValid() || dobMoment.isAfter(moment(), 'day')) {
+  // getTime() returns NaN for invalid dates
+  if (Number.isNaN(date.getTime()) || date > new Date()) {
     return { formattedDob: 'Not added', action: 'Add' }
   }
 
   return {
-    formattedDob: dobMoment.format('D MMMM YYYY'),
+    formattedDob: presenters.formatLongDate(date),
     action: 'Change'
   }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FLS2-13

## Summary

Moment.js is officially deprecated and in maintenance-only mode. This PR removes it entirely from the internal frontend, replacing its usage with native JavaScript `Date` APIs and `formatLongDate` from the engine.

This mirrors the equivalent change on the external frontend (DEFRA/fcp-sfd-frontend#472). In this repo Moment.js was only used in a single presenter, so the change is small.

## Changes

- Removed `moment` from `package.json`
- Replaced `moment().format('D MMMM YYYY')` with `presenters.formatLongDate()` from the engine in `personal-details-presenter.js`, using native `Date` for parsing and future-date validation
- Bumped `@defra/fcp-sfd-frontend-engine` from `0.20.0` to `0.22.0` to consume the shared `formatLongDate` presenter

## Notes

Requires engine `>= 0.22.0`, which exports `presenters.formatLongDate`.