### PR TITLE
Fix address selection bugs

### DIFF
--- a/src/routes/business/business-address-enter-routes.js
+++ b/src/routes/business/business-address-enter-routes.js
@@ -26,7 +26,7 @@ const postBusinessAddressEnter = {
   options: {
     pre: [validateSbi],
     validate: {
-      payload: schemas.business.address,
+      payload: schemas.business.details.address,
       options: { abortEarly: false },
       failAction: async (request, h, err) => {
         const { yar, auth, payload } = request

--- a/src/views/business/business-address-select.njk
+++ b/src/views/business/business-address-select.njk
@@ -39,7 +39,10 @@
             label: {
               html: '<div class="govuk-label govuk-!-font-weight-bold">Select an address</div>'
             },
-            items: displayAddresses
+            items: displayAddresses,
+            errorMessage: errors.addresses and {
+              text: errors.addresses.text
+            }
           }) }}
         </fieldset>
 

--- a/src/views/personal/personal-address-select.njk
+++ b/src/views/personal/personal-address-select.njk
@@ -39,7 +39,10 @@
             label: {
               html: '<div class="govuk-label govuk-!-font-weight-bold">Select an address</div>'
             },
-            items: displayAddresses
+            items: displayAddresses,
+            errorMessage: errors.addresses and {
+              text: errors.addresses.text
+            }
           }) }}
         </fieldset>
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FLS2-54

During testing for the above ticket two bugs were found in the address pages. The drop down component was not correctly displaying errors when a user failed to select an address. The schemas for the business address pages were not using the correct one from the engine and therefore the validation was failing. Both issues are fixed in this PR.